### PR TITLE
P1 UX改善: メトリクス説明・プライバシー根拠・クイックスタート・初心者ガイド

### DIFF
--- a/docs/catalog/src/components/BeginnerGuide.tsx
+++ b/docs/catalog/src/components/BeginnerGuide.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+
+const STORAGE_KEY = "beginner-guide-closed";
+
+export function BeginnerGuide() {
+  const [isOpen, setIsOpen] = useState(() => {
+    return localStorage.getItem(STORAGE_KEY) !== "true";
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [isOpen]);
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between bg-blue-50 border border-blue-200 rounded-t-lg px-5 py-3 text-left hover:bg-blue-100 transition-colors"
+        style={{
+          borderRadius: isOpen ? "0.5rem 0.5rem 0 0" : "0.5rem",
+        }}
+      >
+        <span className="font-semibold text-blue-800 flex items-center gap-2">
+          <span>&#x1F530;</span> 初めての方へ：どの手法を選べばいいか迷ったら
+        </span>
+        <span className="text-blue-400 text-sm shrink-0 ml-2">
+          {isOpen ? "▲ 閉じる" : "▼ 開く"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="bg-blue-50 border border-t-0 border-blue-200 rounded-b-lg px-5 py-4 border-l-4 border-l-blue-400">
+          <p className="text-sm text-blue-900 mb-4">
+            あなたのデータに合った手法を選びましょう:
+          </p>
+
+          <div className="space-y-4">
+            {/* Single table */}
+            <div>
+              <h3 className="text-sm font-semibold text-blue-800 mb-1 flex items-center gap-1.5">
+                <span>&#x1F4CA;</span> 単一表データ（顧客マスタ等）
+              </h3>
+              <ul className="text-sm text-blue-900 space-y-1 ml-6">
+                <li>
+                  → まずは{" "}
+                  <Link
+                    to="/algorithm/gaussiancopula"
+                    className="font-semibold text-blue-700 underline hover:text-blue-900"
+                  >
+                    GaussianCopula
+                  </Link>{" "}
+                  がおすすめ（高速・安定・チューニング不要）
+                </li>
+                <li>
+                  → より高品質を求めるなら{" "}
+                  <Link
+                    to="/algorithm/ctgan"
+                    className="font-semibold text-blue-700 underline hover:text-blue-900"
+                  >
+                    CTGAN
+                  </Link>
+                  （epochs=100 で Quality 86%）
+                </li>
+              </ul>
+            </div>
+
+            {/* Multi table */}
+            <div>
+              <h3 className="text-sm font-semibold text-blue-800 mb-1 flex items-center gap-1.5">
+                <span>&#x1F517;</span> 複数表データ（マスタ + トランザクション）
+              </h3>
+              <ul className="text-sm text-blue-900 space-y-1 ml-6">
+                <li>
+                  →{" "}
+                  <Link
+                    to="/algorithm/hma"
+                    className="font-semibold text-blue-700 underline hover:text-blue-900"
+                  >
+                    HMA
+                  </Link>
+                  （SDV）が唯一の対応手法。外部キー整合性を自動維持
+                </li>
+              </ul>
+            </div>
+
+            {/* Timeseries */}
+            <div>
+              <h3 className="text-sm font-semibold text-blue-800 mb-1 flex items-center gap-1.5">
+                <span>&#x1F4C8;</span> 時系列データ（センサ・行動ログ等）
+              </h3>
+              <ul className="text-sm text-blue-900 space-y-1 ml-6">
+                <li>
+                  →{" "}
+                  <Link
+                    to="/algorithm/par"
+                    className="font-semibold text-blue-700 underline hover:text-blue-900"
+                  >
+                    PAR
+                  </Link>
+                  （SDV）が対応。自己回帰モデルで時系列パターンを再現
+                </li>
+              </ul>
+            </div>
+
+            {/* Privacy */}
+            <div>
+              <h3 className="text-sm font-semibold text-blue-800 mb-1 flex items-center gap-1.5">
+                <span>&#x1F512;</span> プライバシーを重視する場合
+              </h3>
+              <ul className="text-sm text-blue-900 space-y-1 ml-6">
+                <li>
+                  →{" "}
+                  <Link
+                    to="/algorithm/adsgan"
+                    className="font-semibold text-blue-700 underline hover:text-blue-900"
+                  >
+                    AdsGAN
+                  </Link>{" "}
+                  はプライバシー考慮メカニズムを内蔵
+                </li>
+                <li>
+                  → ただし「合成データ＝安全」ではないことに注意
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/catalog/src/components/ExperimentTable.test.tsx
+++ b/docs/catalog/src/components/ExperimentTable.test.tsx
@@ -28,6 +28,7 @@ describe("ExperimentTable", () => {
   it("shows baseline reference note", () => {
     const algo = mockAlgorithms[0];
     render(<ExperimentTable experiments={algo.experiments} />);
-    expect(screen.getByText(/ベースライン/)).toBeInTheDocument();
+    const matches = screen.getAllByText(/ベースライン/);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/docs/catalog/src/components/ExperimentTable.tsx
+++ b/docs/catalog/src/components/ExperimentTable.tsx
@@ -8,6 +8,39 @@ type ExperimentTableProps = {
 const BASELINE_ACC = 0.8558;
 const BASELINE_F1 = 0.8513;
 
+const METRIC_TOOLTIPS: Record<string, string> = {
+  quality:
+    "元データの統計的特性（分布・相関）をどの程度再現できたかのスコア（0〜1、高いほど良い）",
+  tstr_acc:
+    "合成データで学習→実データでテスト時の正解率。ベースライン(0.856)に近いほど良い",
+  tstr_f1:
+    "合成データで学習→実データでテスト時のF1スコア。ベースライン(0.851)に近いほど良い",
+  dcr_mean:
+    "合成データの各レコードと元データの最近傍距離の平均。高いほどプライバシー保護が強い",
+  time:
+    "CPU環境での学習+生成の合計時間。環境依存のため相対比較のみ推奨",
+};
+
+function TooltipHeader({ label, tooltipKey }: { label: string; tooltipKey: string }) {
+  const tip = METRIC_TOOLTIPS[tooltipKey];
+  if (!tip) return <>{label}</>;
+  return (
+    <span className="inline-flex items-center gap-1">
+      {label}
+      <span className="relative group cursor-help">
+        <span className="text-gray-400 text-xs">(&#63;)</span>
+        <span
+          className="invisible group-hover:visible absolute z-20 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 max-w-xs bg-white text-gray-700 text-sm font-normal rounded-lg shadow-lg border border-gray-200 px-3 py-2 whitespace-normal"
+          role="tooltip"
+        >
+          {tip}
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-white" />
+        </span>
+      </span>
+    </span>
+  );
+}
+
 function qualityColor(value: number | undefined): string {
   if (value == null) return "";
   if (value >= 0.8) return "bg-green-100 text-green-800";
@@ -80,6 +113,20 @@ export function ExperimentTable({ experiments }: ExperimentTableProps) {
 
   return (
     <div>
+      {/* 色分け凡例 */}
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-gray-600 mb-3 bg-gray-50 rounded-lg px-4 py-2.5 border border-gray-200">
+        <span className="font-semibold text-gray-700 mr-1">色分け凡例:</span>
+        <span className="inline-flex items-center gap-1"><span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" /> 良好</span>
+        <span className="inline-flex items-center gap-1"><span className="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500" /> 注意</span>
+        <span className="inline-flex items-center gap-1"><span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" /> 要検討</span>
+        <span className="text-gray-400">|</span>
+        <span>Quality: &ge;0.8 緑, &ge;0.7 黄, &lt;0.7 赤</span>
+        <span className="text-gray-400">|</span>
+        <span>TSTR: ベースライン比 &ge;95% 緑, &ge;85% 黄, &lt;85% 赤</span>
+        <span className="text-gray-400">|</span>
+        <span>DCR: &ge;0.4 緑(安全), &ge;0.2 黄, &lt;0.2 赤(リスク)</span>
+      </div>
+
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">
           <thead>
@@ -87,19 +134,29 @@ export function ExperimentTable({ experiments }: ExperimentTableProps) {
               <th className="px-3 py-2.5 font-semibold text-gray-700">Library</th>
               <th className="px-3 py-2.5 font-semibold text-gray-700">Params</th>
               {hasQuality && (
-                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">Quality</th>
+                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">
+                  <TooltipHeader label="Quality" tooltipKey="quality" />
+                </th>
               )}
               {hasTstrAcc && (
-                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">TSTR Acc</th>
+                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">
+                  <TooltipHeader label="TSTR Acc" tooltipKey="tstr_acc" />
+                </th>
               )}
               {hasTstrF1 && (
-                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">TSTR F1</th>
+                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">
+                  <TooltipHeader label="TSTR F1" tooltipKey="tstr_f1" />
+                </th>
               )}
               {hasDcr && (
-                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">DCR Mean</th>
+                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">
+                  <TooltipHeader label="DCR Mean" tooltipKey="dcr_mean" />
+                </th>
               )}
               {hasTime && (
-                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">実行時間</th>
+                <th className="px-3 py-2.5 font-semibold text-gray-700 text-right">
+                  <TooltipHeader label="実行時間" tooltipKey="time" />
+                </th>
               )}
             </tr>
           </thead>

--- a/docs/catalog/src/components/QuickStartSection.tsx
+++ b/docs/catalog/src/components/QuickStartSection.tsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+
+type LibraryCode = {
+  install: string;
+  code: string;
+};
+
+type AlgorithmCodeMap = {
+  [library: string]: LibraryCode | undefined;
+};
+
+function getSdvImportPath(algorithmId: string): string {
+  switch (algorithmId) {
+    case "hma":
+      return "sdv.multi_table";
+    case "par":
+      return "sdv.sequential";
+    default:
+      return "sdv.single_table";
+  }
+}
+
+function getSdvClassName(algorithmId: string): string | null {
+  switch (algorithmId) {
+    case "gaussiancopula":
+      return "GaussianCopulaSynthesizer";
+    case "ctgan":
+      return "CTGANSynthesizer";
+    case "hma":
+      return "HMASynthesizer";
+    case "par":
+      return "PARSynthesizer";
+    default:
+      return null;
+  }
+}
+
+function getSdvParams(algorithmId: string): string {
+  switch (algorithmId) {
+    case "ctgan":
+      return "metadata, epochs=100";
+    default:
+      return "metadata";
+  }
+}
+
+function getSdvFitGenerate(algorithmId: string): string {
+  if (algorithmId === "hma") {
+    return `# 複数テーブルのメタデータを設定
+metadata = Metadata.detect_from_dataframes(tables)
+
+# 学習と生成
+synthesizer = HMASynthesizer(metadata)
+synthesizer.fit(tables)
+synthetic_data = synthesizer.sample()`;
+  }
+  if (algorithmId === "par") {
+    return `# 時系列メタデータの設定
+metadata = Metadata.detect_from_dataframe(real_data)
+
+# 学習と生成
+synthesizer = PARSynthesizer(metadata)
+synthesizer.fit(real_data)
+synthetic_data = synthesizer.sample(num_sequences=100)`;
+  }
+  return `# メタデータの自動検出
+metadata = Metadata.detect_from_dataframe(real_data)
+
+# 学習と生成
+synthesizer = ${getSdvClassName(algorithmId)}(${getSdvParams(algorithmId)})
+synthesizer.fit(real_data)
+synthetic_data = synthesizer.sample(num_rows=1000)`;
+}
+
+function getSynthCityPluginName(algorithmId: string): string | null {
+  switch (algorithmId) {
+    case "ctgan":
+      return "ctgan";
+    case "tvae":
+      return "tvae";
+    case "bayesian_network":
+      return "bayesian_network";
+    case "adsgan":
+      return "adsgan";
+    case "nflow":
+      return "nflow";
+    default:
+      return null;
+  }
+}
+
+function getCodeMap(algorithmId: string): AlgorithmCodeMap {
+  const map: AlgorithmCodeMap = {};
+
+  // SDV
+  const sdvClass = getSdvClassName(algorithmId);
+  if (sdvClass) {
+    const importPath = getSdvImportPath(algorithmId);
+    map["SDV"] = {
+      install: "pip install sdv",
+      code: `from ${importPath} import ${sdvClass}
+from sdv.metadata import Metadata
+
+${getSdvFitGenerate(algorithmId)}`,
+    };
+  }
+
+  // SynthCity
+  const synthCityPlugin = getSynthCityPluginName(algorithmId);
+  if (synthCityPlugin) {
+    map["SynthCity"] = {
+      install: "pip install synthcity",
+      code: `from synthcity.plugins import Plugins
+from synthcity.plugins.core.dataloader import GenericDataLoader
+
+loader = GenericDataLoader(real_data)
+plugin = Plugins().get("${synthCityPlugin}")
+plugin.fit(loader)
+synthetic_data = plugin.generate(count=1000).dataframe()`,
+    };
+  }
+
+  // ydata
+  if (algorithmId === "ctgan") {
+    map["ydata-synthetic"] = {
+      install: "pip install ydata-synthetic",
+      code: `from ydata_synthetic.synthesizers.regular import RegularSynthesizer
+from ydata_synthetic.synthesizers import ModelParameters, TrainParameters
+
+synth = RegularSynthesizer(modelname='ctgan', model_parameters=ModelParameters(batch_size=500))
+synth.fit(data=real_data, train_arguments=TrainParameters(epochs=100), num_cols=num_cols, cat_cols=cat_cols)
+synthetic_data = synth.sample(1000)`,
+    };
+  }
+
+  return map;
+}
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="mb-3">
+      <div className="flex items-center justify-between bg-gray-800 rounded-t-lg px-4 py-1.5">
+        <span className="text-xs text-gray-400">{label}</span>
+        <button
+          onClick={handleCopy}
+          className="text-xs text-gray-400 hover:text-white transition-colors px-2 py-0.5 rounded"
+        >
+          {copied ? "コピーしました!" : "コピー"}
+        </button>
+      </div>
+      <pre className="bg-gray-900 text-green-400 rounded-b-lg p-4 overflow-x-auto text-sm leading-relaxed">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+type Props = {
+  libraries: string[];
+  algorithmId: string;
+};
+
+export function QuickStartSection({ libraries, algorithmId }: Props) {
+  const codeMap = getCodeMap(algorithmId);
+  const availableLibraries = libraries.filter((lib) => codeMap[lib]);
+  const [activeTab, setActiveTab] = useState(availableLibraries[0] ?? "");
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (availableLibraries.length === 0) {
+    return null;
+  }
+
+  const activeCode = codeMap[activeTab];
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between text-left"
+      >
+        <h2 className="font-semibold text-gray-800 text-lg flex items-center gap-2">
+          <span>&#9889;</span> クイックスタート
+        </h2>
+        <span className="text-gray-400 text-sm">
+          {isOpen ? "▲ 閉じる" : "▼ 開く"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="mt-4">
+          {/* Library tabs */}
+          {availableLibraries.length > 1 && (
+            <div className="flex gap-1 mb-4 border-b border-gray-200">
+              {availableLibraries.map((lib) => (
+                <button
+                  key={lib}
+                  onClick={() => setActiveTab(lib)}
+                  className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${
+                    activeTab === lib
+                      ? "bg-gray-900 text-green-400"
+                      : "text-gray-600 hover:text-gray-800 hover:bg-gray-100"
+                  }`}
+                >
+                  {lib}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {activeCode && (
+            <>
+              <CodeBlock code={activeCode.install} label="インストール" />
+              <CodeBlock code={activeCode.code} label="サンプルコード" />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/catalog/src/pages/DetailPage.tsx
+++ b/docs/catalog/src/pages/DetailPage.tsx
@@ -1,14 +1,63 @@
+import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAlgorithms } from "../hooks/useAlgorithms";
 import { CATEGORY_LABELS, DATA_TYPE_LABELS } from "../constants/categories";
 import { MetricsBadge } from "../components/MetricsBadge";
 import { ExperimentTable } from "../components/ExperimentTable";
+import { QuickStartSection } from "../components/QuickStartSection";
+import type { PrivacyRiskLevel } from "../types/algorithm";
 
 const PRIVACY_MECHANISM_LABELS: Record<string, string> = {
   none: "なし（プライバシー保護機構なし）",
   identifiability_penalty: "識別可能性ペナルティ（生成データが元データに近づきすぎないよう制約）",
   differential_privacy: "差分プライバシー（数学的なプライバシー保証）",
 };
+
+const PRIVACY_BANNER_KEY = "syntheticdata-catalog-privacy-banner-dismissed";
+
+const PRIVACY_RISK_RATIONALE: Record<PrivacyRiskLevel, string> = {
+  low: "DCR 5th percentile > 0.2: 最も近い合成レコードでも元データから十分な距離があります",
+  medium:
+    "DCR 5th percentile 0.05〜0.2: 一部の合成レコードが元データに近い可能性があります",
+  high: "DCR 5th percentile < 0.05: 元データに非常に近い合成レコードが存在する可能性があり、再識別リスクがあります",
+};
+
+function PrivacyWarningBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(PRIVACY_BANNER_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(PRIVACY_BANNER_KEY, "1");
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="bg-amber-50 border border-amber-300 rounded-lg px-4 py-3 mb-6 flex items-start gap-3">
+      <span className="text-lg shrink-0 mt-0.5" aria-hidden="true">&#9888;&#65039;</span>
+      <p className="text-sm text-amber-900 flex-1">
+        合成データは匿名データではありません。本番データに適用する前に、データの性質・用途に応じたプライバシー評価を実施してください。
+      </p>
+      <button
+        onClick={handleDismiss}
+        className="text-amber-600 hover:text-amber-800 text-lg font-bold leading-none shrink-0 cursor-pointer"
+        aria-label="閉じる"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
 
 const CATEGORY_COLORS: Record<string, string> = {
   gan: "bg-purple-100 text-purple-800",
@@ -56,6 +105,9 @@ export function DetailPage() {
 
   return (
     <div className="max-w-4xl mx-auto">
+      {/* ===== 注意バナー ===== */}
+      <PrivacyWarningBanner />
+
       {/* ===== A. ヘッダーセクション ===== */}
       <div className="mb-6">
         <Link
@@ -85,11 +137,31 @@ export function DetailPage() {
               </span>
             ))}
 
-            {/* プライバシーリスクバッジ */}
+            {/* プライバシーリスクバッジ + 判定根拠 */}
             {algorithm.privacy_risk_level && (
               <MetricsBadge level={algorithm.privacy_risk_level} />
             )}
           </div>
+
+          {/* プライバシーリスク判定根拠 */}
+          {algorithm.privacy_risk_level && (
+            <div className="mt-3 text-sm text-gray-600 bg-gray-50 rounded-lg px-4 py-2.5 border border-gray-200">
+              <span className="font-semibold text-gray-700">判定根拠: </span>
+              {PRIVACY_RISK_RATIONALE[algorithm.privacy_risk_level]}
+              {(() => {
+                const dcr5th = algorithm.experiments
+                  .map((e) => e.metrics.dcr_5th_percentile)
+                  .filter((v): v is number => v != null);
+                if (dcr5th.length === 0) return null;
+                const minVal = Math.min(...dcr5th);
+                return (
+                  <span className="ml-1 font-mono text-gray-500">
+                    (実測値: DCR 5th percentile = {minVal.toFixed(4)})
+                  </span>
+                );
+              })()}
+            </div>
+          )}
 
           {/* 対応データタイプ */}
           <div className="mt-3 flex flex-wrap gap-1.5">
@@ -246,7 +318,10 @@ export function DetailPage() {
         <ExperimentTable experiments={algorithm.experiments} />
       </div>
 
-      {/* ===== E. 参考文献セクション ===== */}
+      {/* ===== E. クイックスタートセクション ===== */}
+      <QuickStartSection libraries={algorithm.libraries} algorithmId={algorithm.id} />
+
+      {/* ===== F. 参考文献セクション ===== */}
       {(algorithm.reference || algorithm.privacy_mechanism) && (
         <div className="bg-white rounded-lg shadow-md p-6 mb-6">
           <h2 className="font-semibold text-gray-800 text-lg mb-4">参考情報</h2>

--- a/docs/catalog/src/pages/ListPage.tsx
+++ b/docs/catalog/src/pages/ListPage.tsx
@@ -3,6 +3,7 @@ import { useAlgorithms } from "../hooks/useAlgorithms";
 import { useFilter } from "../hooks/useFilter";
 import { FilterPanel } from "../components/FilterPanel";
 import { AlgorithmCard } from "../components/AlgorithmCard";
+import { BeginnerGuide } from "../components/BeginnerGuide";
 
 export function ListPage() {
   const { algorithms, loading, error } = useAlgorithms();
@@ -131,6 +132,9 @@ export function ListPage() {
           </div>
         </div>
       )}
+
+      {/* Beginner guide */}
+      <BeginnerGuide />
 
       <div className="flex gap-6">
         {/* Desktop filter panel */}


### PR DESCRIPTION
## Summary

ペルソナベースのユーザーストーリー (#17) に基づく P1（最優先）改善4項目を実装。

## 変更内容

### 4-1 メトリクスツールチップ (US-04)
- ExperimentTable の各メトリクス名に `(?)` アイコン追加
- ホバーで日本語の説明ツールチップを表示（Tailwind CSS のみ、ライブラリ不要）
- テーブル上部に色分け凡例（🟢良好 / 🟡注意 / 🔴要検討 + 閾値説明）

### 4-2 プライバシーリスク根拠の明示 (US-05, US-11)
- 詳細ページにリスクレベルの判定根拠テキスト（DCR 5th percentile ベース）
- 実験データから DCR 5th percentile の実測値を表示
- 「合成データは匿名データではありません」注意バナー（閉じると localStorage 記憶）

### 4-3 クイックスタートセクション (US-07)
- 詳細ページに `QuickStartSection` コンポーネント追加
- ライブラリ別タブ切替（SDV / SynthCity / ydata）
- pip install + 最小限のサンプルコード（アルゴリズム固有、8種対応）
- コピーボタン付きダークテーマコードブロック

### 4-4 初心者向け推奨ガイド (US-09)
- 一覧ページに `BeginnerGuide` コンポーネント追加
- データ構造別おすすめ（単一表→GaussianCopula、複数表→HMA、時系列→PAR、プライバシー→AdsGAN）
- 各推奨手法名はリンク（詳細ページへ遷移）
- 折りたたみ式、閉じた状態を localStorage 記憶

## Test plan
- [x] `npm run build` 成功
- [x] `npm run test` 30テスト全パス
- [ ] ローカルで見た目確認

Refs #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)