### PR TITLE
データセット名に元データのソースURLリンクを追加 (#33)

### DIFF
--- a/docs/catalog/public/data/experiment-cases.json
+++ b/docs/catalog/public/data/experiment-cases.json
@@ -9,6 +9,7 @@
     },
     "dataset": {
       "name": "Adult Census",
+      "source_url": "https://archive.ics.uci.edu/dataset/2/adult",
       "rows": 32561,
       "columns": 15,
       "features": ["年齢", "職業", "学歴", "婚姻状況", "人種", "性別", "労働時間", "収入区分"]
@@ -83,6 +84,7 @@
     },
     "dataset": {
       "name": "Insurance",
+      "source_url": "https://www.kaggle.com/datasets/mirichoi0218/insurance",
       "rows": 20000,
       "columns": 27,
       "features": ["年齢", "性別", "BMI", "扶養家族数", "喫煙有無", "地域", "保険料", "職業", "運動頻度"]
@@ -117,6 +119,7 @@
     },
     "dataset": {
       "name": "Fake Companies",
+      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
       "rows": 12,
       "columns": 12,
       "features": ["会社名", "部署", "社員ID", "年齢", "入社時年齢", "勤続年数", "給与", "年間ボーナス", "経験年数", "正社員", "パート", "契約社員"]
@@ -143,6 +146,7 @@
     },
     "dataset": {
       "name": "Fake Hotels",
+      "source_url": "https://docs.sdv.dev/sdv/multi-table-data/data-preparation/loading-data/demo-data",
       "rows": 668,
       "columns": 15,
       "features": ["hotel_id", "hotel_name", "city", "guest_email", "checkin_date", "checkout_date", "room_rate", "room_type"]
@@ -169,6 +173,7 @@
     },
     "dataset": {
       "name": "IMDB Small",
+      "source_url": "https://docs.sdv.dev/sdv/multi-table-data/data-preparation/loading-data/demo-data",
       "rows": 4395,
       "columns": 26,
       "features": ["movies(36)", "actors(1907)", "directors(34)", "roles(1989)", "movies_genres(103)", "movies_directors(41)", "directors_genres(285)"]
@@ -195,6 +200,7 @@
     },
     "dataset": {
       "name": "NASDAQ 100 (2019)",
+      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
       "rows": 25784,
       "columns": 8,
       "features": ["Symbol", "Date", "Open", "High", "Low", "Close", "Volume", "Sector"]
@@ -221,6 +227,7 @@
     },
     "dataset": {
       "name": "Daily Weather 2020（センサーデータ代替）",
+      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
       "rows": 13664,
       "columns": 11,
       "features": ["観測地点(122拠点)", "国", "緯度", "経度", "日付", "最高気温", "最低気温", "湿度", "気圧", "降水確率"]

--- a/docs/catalog/src/pages/CaseDetailPage.tsx
+++ b/docs/catalog/src/pages/CaseDetailPage.tsx
@@ -135,7 +135,21 @@ export function CaseDetailPage() {
       <div className="bg-white border border-gray-200 rounded-xl p-6 mb-6">
         <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">使用データ</h2>
         <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 mb-3">
-          <span className="text-lg font-bold text-gray-900">{c.dataset.name}</span>
+          {c.dataset.source_url ? (
+            <a
+              href={c.dataset.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-lg font-bold text-blue-700 hover:text-blue-900 hover:underline inline-flex items-center gap-1"
+            >
+              {c.dataset.name}
+              <svg className="w-4 h-4 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </a>
+          ) : (
+            <span className="text-lg font-bold text-gray-900">{c.dataset.name}</span>
+          )}
           <span className="text-sm text-gray-500">
             {c.dataset.rows.toLocaleString()}行 × {c.dataset.columns}列
           </span>

--- a/docs/catalog/src/types/experiment-case.ts
+++ b/docs/catalog/src/types/experiment-case.ts
@@ -28,6 +28,7 @@ export type ExperimentCase = {
   };
   dataset: {
     name: string;
+    source_url?: string;
     rows: number;
     columns: number;
     features: string[];


### PR DESCRIPTION
## Summary
- `experiment-cases.json` の各データセットに `source_url` フィールドを追加（7データセット分）
- `CaseDetailPage.tsx` でデータセット名を外部リンク化（↗アイコン付き、新しいタブで開く）
- TypeScript型定義に `source_url` を追加

## Test plan
- [ ] 事例詳細ページでデータセット名がリンクになっていること
- [ ] リンクをクリックすると外部ページが新しいタブで開くこと
- [ ] `source_url` がない場合は従来通りのテキスト表示になること

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)