### PR TITLE
GitHub Pages の SPA ルーティング修正: 404.html を追加 (#26)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Build
         working-directory: docs/catalog
         run: npm run build
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp docs/catalog/dist/index.html docs/catalog/dist/404.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
直接URLアクセス時にGitHub Pagesの404になる問題を修正。
ビルド後に index.html を 404.html にコピーし、
クライアントサイドルーティングにフォールバックさせる。