### PR TITLE
docs: SPA ルーティングの既知制約（GitHub Pages 404 ステータス）を明文化 (#51)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,6 +48,9 @@ jobs:
           name: playwright-report
           path: docs/catalog/playwright-report/
           retention-days: 7
+      # SPA routing fallback: GitHub Pages は未知のパスで 404.html を返す。
+      # index.html をコピーしておくことで React Router がルーティングを復元できる。
+      # 注: HTTP ステータスは 404 のまま。SEO 上の既知制約は README 参照。
       - name: Copy index.html to 404.html for SPA routing
         run: cp docs/catalog/dist/index.html docs/catalog/dist/404.html
       - name: Upload artifact

--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -82,3 +82,35 @@ export default tseslint.config({
   },
 })
 ```
+
+## SPA ルーティングと GitHub Pages の制約
+
+### 現在の挙動
+
+このカタログサイトは React Router の `BrowserRouter` を使用している。
+GitHub Pages へのデプロイ時、`index.html` を `404.html` にコピーすることで SPA のルーティングを実現している（`.github/workflows/deploy-pages.yml` 参照）。
+
+### 既知の制約
+
+`/case/:id` や `/algorithm/:id` などのルートに直接アクセス（またはリロード）すると、
+GitHub Pages は **HTTP 404 ステータス**で応答する。
+
+ブラウザで開いた場合は `404.html`（= `index.html` のコピー）がフォールバックとして返され、
+React Router が URL を解釈してルーティングを復元するため**画面上は正常に表示される**。
+しかしステータスコードは 404 のままであるため、以下の影響がある：
+
+- 検索エンジン・SNS クローラー・OGP 取得系ツールが「存在しないページ」として扱う
+- 監視ツール（UptimeRobot 等）で誤検知される可能性がある
+
+### 監視ツールを使用する場合の推奨
+
+監視系ツールを接続する際は、`/case/:id` 等の個別ルートではなくトップの `/` のみを監視対象にすることを推奨する。
+
+### 将来対応の選択肢
+
+| 案 | 内容 | 備考 |
+|---|---|---|
+| 案1 | `HashRouter` に切り替え（URL が `/#/case/:id` 形式になる） | SEO・ステータス問題が解消。URL の見栄えは変わる |
+| 案2 | Cloudflare Pages / Netlify に移行 | リダイレクトルールで SPA を適切に扱える。インフラ変更大 |
+
+OGP 対応や SEO を重視する段階になったら案1への切替を検討する。


### PR DESCRIPTION
## 概要

コード変更なし、ドキュメント追加のみ。

GitHub Pages の SPA 直アクセスで HTTP 404 ステータスが返る問題について、**案3（現状維持 + 明文化）**を採用し、既知制約をドキュメントに明記します。

Closes #51

## 変更内容

### `docs/catalog/README.md`
「SPA ルーティングと GitHub Pages の制約」セクションを新設:
- 現在の挙動（BrowserRouter + 404.html コピー方式）の説明
- 既知制約（直接アクセスで HTTP 404 ステータスが返る）とその影響範囲
- 監視ツール利用時の推奨（`/` のみを監視対象にすること）
- 将来対応の選択肢（HashRouter 切替 / Cloudflare Pages 移行）

### `.github/workflows/deploy-pages.yml`
`cp docs/catalog/dist/index.html docs/catalog/dist/404.html` の直前にインラインコメントを追加:
- なぜ 404.html のコピーが必要か
- HTTP ステータスが 404 のままである旨の注記

## 採用方針の理由

- PR #55 で Playwright E2E が BrowserRouter 前提で組まれており、HashRouter への切替は URL 仕様変更を伴う
- SEO / OGP の優先度は現時点では低い（社内カタログ的用途）
- 将来 OGP 強化や検索流入を重視する段階になったら HashRouter 切替を再検討する

## テスト

- `npm run build` 成功を確認（メインリポジトリの docs/catalog で実行）
- YAML 構文は CI で検証される

🤖 Generated with [Claude Code](https://claude.com/claude-code)