### PR TITLE
[#60] ユーザコメント対応: QuickStart の実行可能化とアルゴリズム→事例の逆リンク

### DIFF
--- a/docs/catalog/public/data/experiment-cases.json
+++ b/docs/catalog/public/data/experiment-cases.json
@@ -138,8 +138,8 @@
       "use_case": "データ拡張・匿名化"
     },
     "dataset": {
-      "name": "Insurance",
-      "source_url": "https://www.kaggle.com/datasets/mirichoi0218/insurance",
+      "name": "Insurance (SDV 組み込みデモ, 拡張版)",
+      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
       "rows": 20000,
       "columns": 27,
       "features": [
@@ -327,7 +327,7 @@
     },
     "dataset": {
       "name": "NASDAQ 100 (2019)",
-      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
+      "source_url": "https://docs.sdv.dev/sdv/sequential-data/data-preparation/loading-data",
       "rows": 25784,
       "columns": 8,
       "features": [
@@ -371,7 +371,7 @@
     },
     "dataset": {
       "name": "Daily Weather 2020（センサーデータ代替）",
-      "source_url": "https://docs.sdv.dev/sdv/single-table-data/data-preparation/loading-data",
+      "source_url": "https://docs.sdv.dev/sdv/sequential-data/data-preparation/loading-data",
       "rows": 13664,
       "columns": 11,
       "features": [

--- a/docs/catalog/src/components/QuickStartSection.tsx
+++ b/docs/catalog/src/components/QuickStartSection.tsx
@@ -46,27 +46,66 @@ function getSdvParams(algorithmId: string): string {
 
 function getSdvFitGenerate(algorithmId: string): string {
   if (algorithmId === "hma") {
-    return `# 複数テーブルのメタデータを設定
-metadata = Metadata.detect_from_dataframes(tables)
+    return `# --- データの準備 ---
+# Option A: SDV 組み込みデモデータ（複数表、すぐ動く）
+from sdv.datasets.demo import download_demo
+tables, metadata = download_demo(
+    modality='multi_table',
+    dataset_name='fake_hotels'
+)
 
-# 学習と生成
+# Option B: カタログで評価に使った複数表データを使う
+# import pandas as pd
+# from sdv.metadata import Metadata
+# tables = {
+#     'parent': pd.read_csv('parent.csv'),
+#     'child': pd.read_csv('child.csv'),
+# }
+# metadata = Metadata.detect_from_dataframes(tables)
+
+# --- 学習と生成 ---
+from sdv.multi_table import HMASynthesizer
 synthesizer = HMASynthesizer(metadata)
 synthesizer.fit(tables)
 synthetic_data = synthesizer.sample()`;
   }
   if (algorithmId === "par") {
-    return `# 時系列メタデータの設定
-metadata = Metadata.detect_from_dataframe(real_data)
+    return `# --- データの準備 ---
+# Option A: SDV 組み込み時系列デモデータ（NASDAQ100 2019）
+from sdv.datasets.demo import download_demo
+real_data, metadata = download_demo(
+    modality='sequential',
+    dataset_name='nasdaq100_2019'
+)
 
-# 学習と生成
+# Option B: カタログで評価に使った時系列データ（株価・IoT など）
+# import pandas as pd
+# from sdv.metadata import Metadata
+# real_data = pd.read_csv('your_timeseries.csv')
+# metadata = Metadata.detect_from_dataframe(real_data)
+
+# --- 学習と生成 ---
+from sdv.sequential import PARSynthesizer
 synthesizer = PARSynthesizer(metadata)
 synthesizer.fit(real_data)
 synthetic_data = synthesizer.sample(num_sequences=100)`;
   }
-  return `# メタデータの自動検出
-metadata = Metadata.detect_from_dataframe(real_data)
+  return `# --- データの準備 ---
+# Option A: SDV 組み込みデモデータ（すぐ動く）
+from sdv.datasets.demo import download_demo
+real_data, metadata = download_demo(
+    modality='single_table',
+    dataset_name='fake_hotel_guests'
+)
 
-# 学習と生成
+# Option B: カタログで評価に使った実データを使う（Adult census、保険 など）
+# import pandas as pd
+# from sdv.metadata import Metadata
+# real_data = pd.read_csv('your_data.csv')
+# metadata = Metadata.detect_from_dataframe(real_data)
+
+# --- 学習と生成 ---
+from ${getSdvImportPath(algorithmId)} import ${getSdvClassName(algorithmId)}
 synthesizer = ${getSdvClassName(algorithmId)}(${getSdvParams(algorithmId)})
 synthesizer.fit(real_data)
 synthetic_data = synthesizer.sample(num_rows=1000)`;
@@ -95,13 +134,9 @@ function getCodeMap(algorithmId: string): AlgorithmCodeMap {
   // SDV
   const sdvClass = getSdvClassName(algorithmId);
   if (sdvClass) {
-    const importPath = getSdvImportPath(algorithmId);
     map["SDV"] = {
       install: "pip install sdv",
-      code: `from ${importPath} import ${sdvClass}
-from sdv.metadata import Metadata
-
-${getSdvFitGenerate(algorithmId)}`,
+      code: getSdvFitGenerate(algorithmId),
     };
   }
 
@@ -109,8 +144,19 @@ ${getSdvFitGenerate(algorithmId)}`,
   const synthCityPlugin = getSynthCityPluginName(algorithmId);
   if (synthCityPlugin) {
     map["SynthCity"] = {
-      install: "pip install synthcity",
-      code: `from synthcity.plugins import Plugins
+      install: "pip install synthcity scikit-learn",
+      code: `# --- データの準備 ---
+# Option A: sklearn のデモデータ（すぐ動く）
+from sklearn.datasets import load_breast_cancer
+data = load_breast_cancer(as_frame=True)
+real_data = data.frame  # 特徴量 + target
+
+# Option B: カタログで評価に使った実データを使う
+# import pandas as pd
+# real_data = pd.read_csv('your_data.csv')
+
+# --- 学習と生成 ---
+from synthcity.plugins import Plugins
 from synthcity.plugins.core.dataloader import GenericDataLoader
 
 loader = GenericDataLoader(real_data)
@@ -123,12 +169,35 @@ synthetic_data = plugin.generate(count=1000).dataframe()`,
   // ydata
   if (algorithmId === "ctgan") {
     map["ydata-synthetic"] = {
-      install: "pip install ydata-synthetic",
-      code: `from ydata_synthetic.synthesizers.regular import RegularSynthesizer
+      install: "pip install ydata-synthetic scikit-learn",
+      code: `# --- データの準備 ---
+# Option A: sklearn のデモデータ（すぐ動く）
+from sklearn.datasets import load_breast_cancer
+data = load_breast_cancer(as_frame=True)
+real_data = data.frame
+num_cols = list(data.feature_names)
+cat_cols = ['target']
+
+# Option B: カタログで評価に使った実データを使う
+# import pandas as pd
+# real_data = pd.read_csv('your_data.csv')
+# num_cols = [...]  # 数値列を列挙
+# cat_cols = [...]  # カテゴリ列を列挙
+
+# --- 学習と生成 ---
+from ydata_synthetic.synthesizers.regular import RegularSynthesizer
 from ydata_synthetic.synthesizers import ModelParameters, TrainParameters
 
-synth = RegularSynthesizer(modelname='ctgan', model_parameters=ModelParameters(batch_size=500))
-synth.fit(data=real_data, train_arguments=TrainParameters(epochs=100), num_cols=num_cols, cat_cols=cat_cols)
+synth = RegularSynthesizer(
+    modelname='ctgan',
+    model_parameters=ModelParameters(batch_size=500)
+)
+synth.fit(
+    data=real_data,
+    train_arguments=TrainParameters(epochs=100),
+    num_cols=num_cols,
+    cat_cols=cat_cols
+)
 synthetic_data = synth.sample(1000)`,
     };
   }

--- a/docs/catalog/src/components/QuickStartSection.tsx
+++ b/docs/catalog/src/components/QuickStartSection.tsx
@@ -48,6 +48,8 @@ function getSdvFitGenerate(algorithmId: string): string {
   if (algorithmId === "hma") {
     return `# --- データの準備 ---
 # Option A: SDV 組み込みデモデータ（複数表、すぐ動く）
+# fake_hotels: ホテル(1) ⇄ 宿泊客(N) の 1:N リレーションを持つ架空予約データ
+# （2 テーブル / 計 668 行 × 15 列, SDV が独自合成）
 from sdv.datasets.demo import download_demo
 tables, metadata = download_demo(
     modality='multi_table',
@@ -71,7 +73,9 @@ synthetic_data = synthesizer.sample()`;
   }
   if (algorithmId === "par") {
     return `# --- データの準備 ---
-# Option A: SDV 組み込み時系列デモデータ（NASDAQ100 2019）
+# Option A: SDV 組み込み時系列デモデータ
+# nasdaq100_2019: NASDAQ100 構成銘柄の 2019 年日次株価（OHLCV + Sector）
+# （25,784 行 × 8 列、銘柄ごとのシーケンス）
 from sdv.datasets.demo import download_demo
 real_data, metadata = download_demo(
     modality='sequential',
@@ -92,6 +96,8 @@ synthetic_data = synthesizer.sample(num_sequences=100)`;
   }
   return `# --- データの準備 ---
 # Option A: SDV 組み込みデモデータ（すぐ動く）
+# fake_hotel_guests: ホテル宿泊客の架空プロフィールデータ
+# （氏名・メール・チェックイン日・料金・ポイント会員フラグ等、SDV が独自合成）
 from sdv.datasets.demo import download_demo
 real_data, metadata = download_demo(
     modality='single_table',

--- a/docs/catalog/src/pages/DetailPage.tsx
+++ b/docs/catalog/src/pages/DetailPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAlgorithms } from "../hooks/useAlgorithms";
+import { useExperimentCases } from "../hooks/useExperimentCases";
 import { CATEGORY_LABELS, DATA_TYPE_LABELS } from "../constants/categories";
 import { MetricsBadge } from "../components/MetricsBadge";
 import { ExperimentTable } from "../components/ExperimentTable";
 import { QuickStartSection } from "../components/QuickStartSection";
 import type { PrivacyRiskLevel } from "../types/algorithm";
+import { DATA_CATEGORY_ICONS, DATA_CATEGORY_LABELS } from "../types/experiment-case";
 
 const PRIVACY_MECHANISM_LABELS: Record<string, string> = {
   none: "なし（プライバシー保護機構なし）",
@@ -71,8 +73,12 @@ const CATEGORY_COLORS: Record<string, string> = {
 export function DetailPage() {
   const { id } = useParams<{ id: string }>();
   const { algorithms, loading, error } = useAlgorithms();
+  const { cases } = useExperimentCases();
 
   const algorithm = algorithms.find((a) => a.id === id);
+  const relatedCases = algorithm
+    ? cases.filter((c) => c.results.some((r) => r.algorithm_id === algorithm.id))
+    : [];
 
   useEffect(() => {
     if (algorithm) {
@@ -326,6 +332,37 @@ export function DetailPage() {
         <h2 className="font-semibold text-gray-800 text-lg mb-4">実験結果</h2>
         <ExperimentTable experiments={algorithm.experiments} filenameBase={algorithm.id} />
       </div>
+
+      {/* ===== D2. 関連事例セクション ===== */}
+      {relatedCases.length > 0 && (
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="font-semibold text-gray-800 text-lg mb-4">
+            この手法を使った事例 ({relatedCases.length})
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {relatedCases.map((c) => (
+              <Link
+                key={c.id}
+                to={`/case/${c.id}`}
+                className="block bg-slate-50 hover:bg-slate-100 border border-slate-200 rounded-lg p-4 transition-colors"
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="text-lg" aria-hidden="true">
+                    {DATA_CATEGORY_ICONS[c.data_category]}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    {DATA_CATEGORY_LABELS[c.data_category]}
+                  </span>
+                </div>
+                <div className="font-semibold text-gray-800 text-sm mb-1">{c.title}</div>
+                <div className="text-xs text-gray-600">
+                  {c.dataset.name} ({c.dataset.rows.toLocaleString()}行 × {c.dataset.columns}列)
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* ===== E. クイックスタートセクション ===== */}
       <QuickStartSection libraries={algorithm.libraries} algorithmId={algorithm.id} />


### PR DESCRIPTION
## Summary
- Closes #60
- **QuickStart**: 各ライブラリのサンプルコードに Option A（組み込みデモデータ）+ Option B（カタログ実データ）のデータ準備ブロックを追加。`real_data` が宙に浮いていた状態を解消
- **アルゴリズム詳細**: 「この手法を使った事例」セクションを新設し、`results[].algorithm_id` でマッチする事例へのカード型リンクを表示

## Test plan
- [ ] `cd docs/catalog && npm run dev` で起動
- [ ] PAR ページで「この手法を使った事例」に株価・気象系事例が表示され `/case/:id` へ遷移できる
- [ ] CTGAN ページで SDV / SynthCity / ydata-synthetic タブ全てにコピペ可能なコードが表示される
- [ ] HMA ページでデモは `multi_table`、PAR ページでデモは `sequential` の `download_demo` が表示される
- [ ] `npx tsc --noEmit` が通る
- [ ] E2E smoke test が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)