### PR TITLE
新規アルゴリズム/事例登録を半自動化するスラッシュコマンド追加

### DIFF
--- a/.claude/commands/add-algorithm.md
+++ b/.claude/commands/add-algorithm.md
@@ -1,0 +1,133 @@
+# 新規アルゴリズム登録
+
+合成データ生成アルゴリズム（ライブラリ）をカタログに登録する。
+ライブラリ環境のスキャフォールディングと `algorithms.json` への新規エントリ追加を行う。
+**実験結果のメトリクスは扱わない**（それは `/add-experiment-case` の責務）。
+
+## 使い方
+
+`/add-algorithm <algorithm_id>` — 例: `/add-algorithm realtabformer`
+
+引数なしの場合はインタラクティブに ID を尋ねる。
+
+## 実行手順
+
+### 1. 入力収集
+
+以下を順に確認する。CLAUDE.md と既存 `algorithms.json` の値域を参照しながら聞き、不明な点だけ質問する。
+
+| 項目 | 用途 | 値の例 |
+|---|---|---|
+| `id` | スラッグ（小文字 + ハイフン or アンダースコア） | `realtabformer` |
+| `name` | UI 表示名 | `REaLTabFormer` |
+| `libraries` | 提供ライブラリ配列 | `["realtabformer"]` / `["SDV"]` |
+| `category` | `gan` / `copula` / `vae` / `bayesian` / `transformer` / `sequential` / `diffusion` / `flow` | `transformer` |
+| `supported_data` | `single_table` / `multi_table` / `timeseries` の配列 | `["single_table","multi_table"]` |
+| `tags` | 3〜4 個のキーワード | `["Transformer","親子テーブル"]` |
+| `use_cases` | 想定ユースケース 2〜4 件 | `["親子テーブル合成"]` |
+| `input_requirements` | 入力要件 | `["GPU推奨"]` |
+| `privacy_mechanism` | `none` / `dp` / `pate` / 個別記述 | `none` |
+| `privacy_risk_level` | `low` / `medium` / `high` / `null` | `medium` |
+| `description` | 3〜4 文の説明 | (本文) |
+| `strengths` | 3〜4 件 | (本文) |
+| `weaknesses` | 2〜3 件 | (本文) |
+| `reference` | 主要論文 / docs URL | `https://...` |
+| `pypi_or_git` | PyPI 名 or `git+https://...` | `realtabformer` |
+| `python_constraint` | `requires-python` 値 | `>=3.10,<3.12` |
+| `extra_dependencies` | pin が必要な依存 | `["transformers>=4.46,<5"]` |
+
+### 2. 重複チェック
+
+```bash
+python3 -c "import json; ids=[a['id'] for a in json.load(open('docs/catalog/public/data/algorithms.json'))]; print('OK' if '<id>' not in ids else 'DUPLICATE: <id>')"
+```
+
+重複していたら処理中止し、ユーザーに既存エントリを更新するか別 ID にするか確認する。
+
+### 3. ライブラリ環境の作成
+
+`libs/<library_dir>/pyproject.toml` を以下のテンプレで作成（既存と同じ書式）:
+
+```toml
+[project]
+name = "synth-<library_dir>"
+version = "0.1.0"
+requires-python = "<python_constraint>"
+dependencies = [
+    "<pypi_or_git>",
+    "pandas",
+    "numpy",
+    # extra_dependencies があればここに追加
+]
+
+[tool.uv]
+package = false
+```
+
+**重要**: `[build-system]` セクションは入れない（uv で hatch ビルドが走り失敗する事例あり）。
+
+### 4. 環境構築 + 動作確認
+
+```bash
+cd libs/<library_dir> && uv sync
+uv run python -c "import <module>; print('<module>', getattr(<module>, '__version__', 'OK'))"
+```
+
+失敗したら traceback を共有しユーザーに対処を求める（バージョン pin の追加など）。
+sudo は使わない。
+
+### 5. `algorithms.json` への追記
+
+新規エントリを以下の形で追加（categoryと近い位置に挿入し、ファイル全体の流れを崩さない）:
+
+```json
+{
+  "id": "<id>",
+  "name": "<name>",
+  "libraries": ["..."],
+  "category": "...",
+  "supported_data": ["..."],
+  "tags": ["..."],
+  "use_cases": ["..."],
+  "input_requirements": ["..."],
+  "privacy_mechanism": "...",
+  "privacy_risk_level": "...",
+  "description": "...",
+  "strengths": ["..."],
+  "weaknesses": ["..."],
+  "reference": "...",
+  "experiments": [],
+  "summary_metrics": {}
+}
+```
+
+`experiments` と `summary_metrics` は空でよい（後で `/add-experiment-case` で埋める）。
+
+### 6. 検証
+
+```bash
+# JSON シンタックス
+python3 -c "import json; json.load(open('docs/catalog/public/data/algorithms.json')); print('JSON OK')"
+# フロントエンドのビルド (TS 型チェック含む)
+cd docs/catalog && npx tsc --noEmit && npm run build 2>&1 | tail -5
+```
+
+ビルド失敗なら原因を特定して修正する。
+
+### 7. 完了サマリ
+
+以下を表示:
+- 作成したファイルパス
+- 追加した `algorithms.json` のエントリ ID
+- 動作確認した import バージョン
+- 次の推奨アクション: 「`/add-experiment-case <case_id>` で実験結果を登録」
+
+## 重要ルール（CLAUDE.md 準拠）
+
+- uv のみ使用、pip/venv/sudo 禁止
+- ファイル名・ディレクトリ名は既存規約に合わせる（`libs/<lib_name>/`）
+- 既存のフォーマットを変更しない（インデント、キー順）
+- インタラクティブ入力は最小限（CLAUDE.md にあるルールで決められる項目は聞かない）
+- スクリプト雛形（`run_<dataset>.py`）は **このスキルでは作らない**。データセット依存だから
+
+$ARGUMENTS

--- a/.claude/commands/add-experiment-case.md
+++ b/.claude/commands/add-experiment-case.md
@@ -1,0 +1,136 @@
+# 新規実験事例の登録
+
+実行・評価済みの合成データ実験を「事例カード」（experiment-cases.json）として登録し、
+かつ各 algorithm の `experiments` 配列にも実験ログを追加する。
+
+このスキルは **既に評価が済んでいる** ことを前提とする。
+評価 JSON（quality_score / tstr / dcr / time_sec などを含む）が `results/<phase>/*.json` に存在しているはず。
+存在しない場合は本スキルを呼ぶ前に評価を実行すること。
+
+## 使い方
+
+`/add-experiment-case <case_id>` — 例: `/add-experiment-case olist-ec-transactions`
+
+引数なしの場合は `case_id` を尋ねる。
+
+## 実行手順
+
+### 1. 入力収集
+
+```
+case_id      : <ARGUMENTS> または対話で取得
+title        : 事例カードのタイトル（80字以内）
+data_category: single_table_master | single_table_transaction | single_table_timeseries | multi_table
+scenario.description : 4-6 文の課題設定（業務文脈・元データ・合成の目的）
+scenario.use_case    : 短いタグ（例: "テストデータ生成（複数表）"）
+dataset.name : データセット表示名
+dataset.rows / columns : 元データのサイズ（複数表ならテーブル合計）
+dataset.features : 主要カラム or テーブル名+件数の配列
+results_source : 評価 JSON のパス（例: results/phase2_olist/olist_eval.json）
+recommendation : 1-3 文の所感・推奨。手法ごとの強み・トレードオフを書く
+```
+
+`results_source` は複数指定可（その場合は `,` 区切り）。
+
+### 2. 重複チェック
+
+```bash
+python3 -c "import json; ids=[c['id'] for c in json.load(open('docs/catalog/public/data/experiment-cases.json'))]; print('OK' if '<case_id>' not in ids else 'DUPLICATE')"
+```
+
+重複ならユーザーに確認（既存を更新 or 別 ID）。
+
+### 3. 評価 JSON から `results[]` を構築
+
+`docs/catalog/src/types/experiment-case.ts` の `CaseResult` 型に合わせて生成する:
+
+```ts
+type CaseResult = {
+  algorithm_id: string;
+  algorithm_name: string;
+  library: string;
+  params: Record<string, unknown>;
+  metrics: {
+    quality_score?: number;
+    tstr_accuracy?: number;
+    tstr_f1?: number;
+    dcr_mean?: number;
+    time_sec?: number;
+  };
+  privacy_risk: "low" | "medium" | "high" | null;
+};
+```
+
+抽出ルール:
+- `algorithm_id` は `algorithms.json` に存在する ID と一致させる（一致しない場合はスキル中止）
+- `algorithm_name` は同 algorithm の `name` フィールドを引く
+- `library` は対応する run_log（`<library>_run_log*.json`）から取得（または対話）
+- `params` は run_log の `epochs` / `batch_size` 等から拾う。なければ `{}`
+- `metrics` は欠けているキーは出力に含めない（フロントは `?` 扱いで「—」を表示）
+- `privacy_risk` は DCR と機構の判断:
+  - DCR ≥ 0.4 かつ `privacy_mechanism != "none"` → `"low"`
+  - DCR ≥ 0.2 → `"medium"`
+  - DCR < 0.2 もしくは特殊 (BayesianNetwork 等) → `"high"`
+  - 計算不可 → `null`
+
+少数 (3 以内) の場合は対話で全件確認。多数なら一覧を表示してユーザーに削除指示を仰ぐ。
+
+### 4. `experiment-cases.json` への追記
+
+末尾の `]` の直前に新規エントリを挿入。**既存エントリは触らない**。
+
+```json
+{
+  "id": "<case_id>",
+  "title": "<title>",
+  "data_category": "<data_category>",
+  "scenario": { "description": "...", "use_case": "..." },
+  "dataset": { "name": "...", "rows": N, "columns": M, "features": ["..."] },
+  "results": [ /* 上で構築した CaseResult[] */ ],
+  "recommendation": "..."
+}
+```
+
+### 5. `algorithms.json` の更新
+
+各 result について、`algorithms.json` の対応 algorithm の `experiments` 配列に以下を追加:
+
+```json
+{
+  "id": "<algorithm_id>_<dataset_slug>",
+  "library": "<library>",
+  "library_version": "<version from run_log _env>",
+  "params": { ... },
+  "dataset": "<dataset_slug>",
+  "data_type": "<single_table|multi_table|timeseries>",
+  "phase": "<phase id (e.g., phase2_olist)>",
+  "metrics": { ...full metrics from eval... }
+}
+```
+
+`summary_metrics` も再計算（`best_quality_score` / `best_tstr_f1` / `best_dcr_mean` / `fastest_time_sec` の更新）。
+
+### 6. 検証
+
+```bash
+# JSON シンタックス
+python3 -c "import json; json.load(open('docs/catalog/public/data/experiment-cases.json')); json.load(open('docs/catalog/public/data/algorithms.json')); print('JSON OK')"
+# 型チェック + ビルド
+cd docs/catalog && npx tsc --noEmit && npm run build 2>&1 | tail -5
+```
+
+### 7. 完了サマリ
+
+- 追加した case_id とリンク先 (https://gghatano.github.io/syntheticdata-generation-catalog/case/<case_id>) を表示
+- algorithms.json で更新された algorithm 一覧を表示
+- `git diff --stat docs/catalog/public/data/` を実行し、変更ファイルを確認
+
+## 重要ルール
+
+- **既存エントリは絶対に書き換えない**（不変性 / append-only。CLAUDE.md の実験結果ルールに準拠）
+- 同一条件の再実行（同じ params + dataset）は別 case_id を勧める（条件サフィックス付き）
+- メトリクスを「null だがそれっぽい値で埋める」のは禁止。実測値のみ記載
+- ビルドが落ちたらコミット・PR を作らない
+- 結果が極端に悪い・予想外でも、**事実を歪めない**。recommendation で考察として書く
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ main          ← 安定版。develop からのマージのみ
 - `/run-all` — 全タスクを依存順に自動実行
 - `/check-progress` — 進捗確認
 - `/create-scripts` — md からスクリプトファイルを生成
+- `/add-algorithm <id>` — 新規ライブラリ環境のスキャフォールド + algorithms.json への登録
+- `/add-experiment-case <case_id>` — 評価済み実験を experiment-cases.json へ登録、algorithms.json の experiments も同期
 
 ## よく使うコマンド
 


### PR DESCRIPTION
## Summary
- `/add-algorithm <id>`: 新規ライブラリの `libs/<id>/pyproject.toml` 雛形作成 + uv sync + import 確認 + `algorithms.json` への新規エントリ追加。実験結果は触らない（責務分離）。
- `/add-experiment-case <case_id>`: 評価済み JSON から `CaseResult[]` を構築し、`experiment-cases.json` と `algorithms.json` の experiments 配列を同期更新。JSON 検証 + `npx tsc --noEmit` + `npm run build` までスキル内で実行。
- どちらも CLAUDE.md の命名規則・不変性ルールに準拠。既存エントリは絶対に書き換えない。

## 背景
issue #65 の Olist 検証で繰り返し発生した定型作業（pyproject.toml 雛形、algorithms.json/experiment-cases.json への append、JSON 検証 + ビルド確認）をスキル化。**ライブラリ固有の罠**（transformers の version pin、REaLTabFormer のバグ回避、IRG の CUDA 必須判定など）はあえてスキルに埋め込まず、人手＋議論で扱う方針。

## Test plan
- [ ] `/add-algorithm` を新規ライブラリで試行
- [ ] `/add-experiment-case` を `results/phase2_olist/olist_eval.json` で試行
- [ ] 既存の Olist 事例が破壊されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)