### PR TITLE
Issue #69: ヘッダー右上に GitHub アイコンを配置

### DIFF
--- a/docs/catalog/src/components/layout/Header.tsx
+++ b/docs/catalog/src/components/layout/Header.tsx
@@ -1,3 +1,5 @@
+import { GITHUB_REPO_URL } from "../../constants/repo";
+
 export function Header() {
   return (
     <header className="bg-blue-600 text-white shadow-md">
@@ -7,8 +9,30 @@ export function Header() {
             Synthetic Data Generation Catalog
           </a>
         </h1>
-        <nav className="text-sm text-blue-100">
+        <nav className="flex items-center gap-4 text-sm text-blue-100">
           <span>合成データ生成手法カタログ</span>
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHubリポジトリ（新しいタブで開く）"
+            title="GitHub リポジトリ"
+            className="inline-flex items-center hover:opacity-80 transition-opacity"
+          >
+            <svg
+              className="w-6 h-6"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z"
+              />
+            </svg>
+          </a>
         </nav>
       </div>
     </header>

--- a/docs/catalog/src/constants/repo.ts
+++ b/docs/catalog/src/constants/repo.ts
@@ -1,0 +1,12 @@
+export const GITHUB_REPO_URL = "https://github.com/gghatano/syntheticdata-generation-catalog";
+export const REPO_BRANCH = "main";
+
+export function buildBlobUrl(path: string, branch: string = REPO_BRANCH): string {
+  const cleanPath = path.replace(/^\/+/, "");
+  return `${GITHUB_REPO_URL}/blob/${branch}/${cleanPath}`;
+}
+
+export function buildRawUrl(path: string, branch: string = REPO_BRANCH): string {
+  const cleanPath = path.replace(/^\/+/, "");
+  return `${GITHUB_REPO_URL}/raw/${branch}/${cleanPath}`;
+}


### PR DESCRIPTION
## Summary
- カタログサイトの右上に GitHub アイコンリンクを追加し、リポジトリへの導線を確保
- リポジトリURL定数 `src/constants/repo.ts` を新設（blob/raw URL ビルダ含む。後続の Issue #63 でも再利用予定）
- 依存追加なし（インライン SVG）。既存の `ExportButtons.tsx` の SVG スタイル方針に揃えた

## Changes
- `docs/catalog/src/constants/repo.ts` (新規): `GITHUB_REPO_URL`, `REPO_BRANCH`, `buildBlobUrl(path)`, `buildRawUrl(path)`
- `docs/catalog/src/components/layout/Header.tsx`: <nav> 内に GitHub アイコンリンクを追加（aria-label, target="_blank", rel="noopener noreferrer"）

## Test plan
- [x] `npm run lint` 通過
- [x] `npm run test` 全 34 件通過
- [x] `npm run build` 成功
- [ ] ローカル `npm run dev` で右上にアイコン表示・新タブ遷移を目視確認
- [ ] モバイル幅 (375px) で崩れないこと

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)