### PR TITLE
Issue #63: 各事例ページに合成・実験スクリプトへの導線を追加

### DIFF
--- a/docs/catalog/public/data/experiment-cases.json
+++ b/docs/catalog/public/data/experiment-cases.json
@@ -127,7 +127,33 @@
         "privacy_risk": "medium"
       }
     ],
-    "recommendation": "高速に試すならGaussianCopula（6秒）。品質重視ならSDV CTGAN 100ep（Quality 86%）。下流タスク性能重視ならBayesianNetwork（TSTR F1 86%、ただしプライバシーリスク高）。"
+    "recommendation": "高速に試すならGaussianCopula（6秒）。品質重視ならSDV CTGAN 100ep（Quality 86%）。下流タスク性能重視ならBayesianNetwork（TSTR F1 86%、ただしプライバシーリスク高）。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "Adult Census データセットを取得し全ライブラリ共通の processed CSV に整形"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_phase1.py",
+        "description": "SDV の GaussianCopula / CTGAN で単一表合成"
+      },
+      {
+        "role": "synthesize",
+        "library": "synthcity",
+        "path": "libs/synthcity/run_phase1.py",
+        "description": "SynthCity の BayesianNetwork / TVAE / AdsGAN / NFlow で単一表合成"
+      },
+      {
+        "role": "synthesize",
+        "library": "ydata",
+        "path": "libs/ydata/run_phase1.py",
+        "description": "ydata-synthetic の CTGAN で単一表合成"
+      }
+    ]
   },
   {
     "id": "insurance-risk-modeling",
@@ -186,7 +212,27 @@
         "privacy_risk": "high"
       }
     ],
-    "recommendation": "GaussianCopulaが品質スコア0.90でCTGAN(0.88)を上回る。 TSTR F1はGC=0.6285, CTGAN=0.6956。 プライバシーリスクはGC=low, CTGAN=high。 保険料（charges）が連続値のため、回帰タスクでの評価も検討の余地あり。"
+    "recommendation": "GaussianCopulaが品質スコア0.90でCTGAN(0.88)を上回る。 TSTR F1はGC=0.6285, CTGAN=0.6956。 プライバシーリスクはGC=low, CTGAN=high。 保険料（charges）が連続値のため、回帰タスクでの評価も検討の余地あり。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "SDV demo (insurance) を取得・整形"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_additional_experiments.py",
+        "description": "GaussianCopula / CTGAN で Insurance データを合成"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_insurance.py",
+        "description": "SDMetrics + TSTR + DCR による品質・プライバシー評価"
+      }
+    ]
   },
   {
     "id": "company-directory",
@@ -232,7 +278,27 @@
         "privacy_risk": "low"
       }
     ],
-    "recommendation": "GaussianCopulaの品質スコアは0.59。 12行の極小データのため、評価指標の統計的信頼性は限定的。 プライバシーリスクはlow。 テスト環境用のダミーデータとしては十分な品質。少量データへの合成データ適用の参考事例。"
+    "recommendation": "GaussianCopulaの品質スコアは0.59。 12行の極小データのため、評価指標の統計的信頼性は限定的。 プライバシーリスクはlow。 テスト環境用のダミーデータとしては十分な品質。少量データへの合成データ適用の参考事例。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "SDV demo (Fake Companies) を取得・整形"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_additional_experiments.py",
+        "description": "GaussianCopula で Fake Companies データを合成"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_fake_companies.py",
+        "description": "12行の極小データに対する品質・プライバシー評価"
+      }
+    ]
   },
   {
     "id": "hotel-reservation-multitable",
@@ -274,7 +340,27 @@
         "privacy_risk": "low"
       }
     ],
-    "recommendation": "HMA の品質スコアは0.65。 FK整合性は完全維持。 プライバシーリスクはlow。 SDV の HMA は複数表の外部キー関係を自動学習し、整合性を維持した合成データを生成可能。"
+    "recommendation": "HMA の品質スコアは0.65。 FK整合性は完全維持。 プライバシーリスクはlow。 SDV の HMA は複数表の外部キー関係を自動学習し、整合性を維持した合成データを生成可能。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "SDV demo (Fake Hotels) を取得し複数表メタデータも保存"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_phase2.py",
+        "description": "SDV HMASynthesizer で hotels / guests を外部キー整合性付きで合成"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_hotel.py",
+        "description": "FK 整合性チェック + 単表 SDMetrics による評価"
+      }
+    ]
   },
   {
     "id": "imdb-movie-database",
@@ -315,7 +401,27 @@
         "privacy_risk": "low"
       }
     ],
-    "recommendation": "HMA の品質スコアは0.52（7テーブル・6リレーション）。 FK整合性は全6関係で維持。 プライバシーリスクはlow。 多対多リレーション（俳優↔映画、映画↔ジャンル）を含む複雑スキーマでも HMA は整合性を維持可能。"
+    "recommendation": "HMA の品質スコアは0.52（7テーブル・6リレーション）。 FK整合性は全6関係で維持。 プライバシーリスクはlow。 多対多リレーション（俳優↔映画、映画↔ジャンル）を含む複雑スキーマでも HMA は整合性を維持可能。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "SDV demo (IMDB Small) を取得し7テーブル分のメタデータを保存"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_additional_experiments.py",
+        "description": "SDV HMASynthesizer で IMDB 7テーブル + 多対多リレーションを合成"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_imdb.py",
+        "description": "6リレーションすべての FK 整合性 + 単表 SDMetrics による評価"
+      }
+    ]
   },
   {
     "id": "olist-ec-transactions",
@@ -346,7 +452,10 @@
         "algorithm_id": "hma",
         "algorithm_name": "HMA",
         "library": "SDV",
-        "params": { "tables_synthesized": "7/7", "sample_size": 5000 },
+        "params": {
+          "tables_synthesized": "7/7",
+          "sample_size": 5000
+        },
         "metrics": {
           "quality_score": 0.6774,
           "tstr_accuracy": 0.0773,
@@ -360,7 +469,12 @@
         "algorithm_id": "realtabformer",
         "algorithm_name": "REaLTabFormer",
         "library": "realtabformer",
-        "params": { "tables_synthesized": "2/7", "sample_orders": 800, "parent_epochs": 30, "child_epochs": 30 },
+        "params": {
+          "tables_synthesized": "2/7",
+          "sample_orders": 800,
+          "parent_epochs": 30,
+          "child_epochs": 30
+        },
         "metrics": {
           "dcr_mean": 0.0338,
           "time_sec": 1054.4
@@ -368,7 +482,33 @@
         "privacy_risk": "high"
       }
     ],
-    "recommendation": "結論として、現環境（CPU）で 7 テーブル全部の合成を実用時間内にこなせるのは SDV HMA のみ。ただし品質には課題が残る。SDV HMA は 7 テーブル全合成を CPU で約 20 分（学習 238s + 生成 963s）、FK 整合性 6/6 ◯・件数分布完璧、一方で price 等の数値分布が崩れ (KS ≈ 0.30)、結合下流タスク (レビュー評価予測) は TSTR Accuracy 0.08 と実用には届かず、「軽量だが品質そこそこのベースライン」の位置づけ。REaLTabFormer は orders → order_items の 1 親-1 子のみ合成 (2/7 テーブル) でも数値分布の再現が極めて優秀 (price KS 0.028、order_status TV 0.008) だが、(a) child に FK 列を出力せず孤立性検証不可、(b) 1 親-1 子しか扱えず 7 テーブル全合成には親子 6 ペア × CPU 17 分 ≈ 100 分以上の累積学習が必要、(c) 複数子テーブル間の整合性は学習されない。IRG は公式リポジトリ (li-jiayu-ljy/irg) が「commercial usage のため full code not disclosed、@placeholder 実装」と明記＋ torch CUDA 12.1 / cupy hard pin で CPU 環境では再現不可と判定し skipped 記録。棲み分け: 「FK 整合性 + 全テーブル合成 → SDV HMA (CPU 可)」「数値分布の精度 + 単一親子で十分 → REaLTabFormer (GPU 推奨)」「論文 IRG → GPU + 著者連絡など別途環境整備が前提」。表の「時間」列は実測値で、HMA は 7/7 テーブル全合成、RTF は 2/7 テーブル分の合計時間 (params 列の tables_synthesized 欄に記載) であることに注意。"
+    "recommendation": "結論として、現環境（CPU）で 7 テーブル全部の合成を実用時間内にこなせるのは SDV HMA のみ。ただし品質には課題が残る。SDV HMA は 7 テーブル全合成を CPU で約 20 分（学習 238s + 生成 963s）、FK 整合性 6/6 ◯・件数分布完璧、一方で price 等の数値分布が崩れ (KS ≈ 0.30)、結合下流タスク (レビュー評価予測) は TSTR Accuracy 0.08 と実用には届かず、「軽量だが品質そこそこのベースライン」の位置づけ。REaLTabFormer は orders → order_items の 1 親-1 子のみ合成 (2/7 テーブル) でも数値分布の再現が極めて優秀 (price KS 0.028、order_status TV 0.008) だが、(a) child に FK 列を出力せず孤立性検証不可、(b) 1 親-1 子しか扱えず 7 テーブル全合成には親子 6 ペア × CPU 17 分 ≈ 100 分以上の累積学習が必要、(c) 複数子テーブル間の整合性は学習されない。IRG は公式リポジトリ (li-jiayu-ljy/irg) が「commercial usage のため full code not disclosed、@placeholder 実装」と明記＋ torch CUDA 12.1 / cupy hard pin で CPU 環境では再現不可と判定し skipped 記録。棲み分け: 「FK 整合性 + 全テーブル合成 → SDV HMA (CPU 可)」「数値分布の精度 + 単一親子で十分 → REaLTabFormer (GPU 推奨)」「論文 IRG → GPU + 著者連絡など別途環境整備が前提」。表の「時間」列は実測値で、HMA は 7/7 テーブル全合成、RTF は 2/7 テーブル分の合計時間 (params 列の tables_synthesized 欄に記載) であることに注意。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_olist.py",
+        "description": "Brazilian E-Commerce (Olist) 7テーブルを uniformly sample (5000 customers ベース) し processed に保存"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_olist_hma.py",
+        "description": "SDV HMASynthesizer で Olist 7/7 テーブルを合成（FK 6本維持）"
+      },
+      {
+        "role": "synthesize",
+        "library": "realtabformer",
+        "path": "libs/realtabformer/run_olist.py",
+        "description": "REaLTabFormer で orders → order_items の親子1ペアを合成（数値分布精度比較用）"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_olist.py",
+        "description": "FK 整合性 + 件数分布 + 単変量分布 + 結合 TSTR (review_score 予測) による評価"
+      }
+    ]
   },
   {
     "id": "stock-price-timeseries",
@@ -412,7 +552,27 @@
         "privacy_risk": "low"
       }
     ],
-    "recommendation": "PAR 128ep の品質スコアは0.50。 自己相関の平均乖離は0.384。 プライバシーリスクはlow。 PAR は銘柄ごとの時系列パターンを学習し、トレンド・ボラティリティを概ね再現するが、列間相関の精度に改善余地がある。"
+    "recommendation": "PAR 128ep の品質スコアは0.50。 自己相関の平均乖離は0.384。 プライバシーリスクはlow。 PAR は銘柄ごとの時系列パターンを学習し、トレンド・ボラティリティを概ね再現するが、列間相関の精度に改善余地がある。",
+    "scripts": [
+      {
+        "role": "prepare",
+        "library": "sdv",
+        "path": "libs/sdv/prepare_data.py",
+        "description": "SDV demo (NASDAQ 100 2019) を取得し時系列メタデータを保存"
+      },
+      {
+        "role": "synthesize",
+        "library": "sdv",
+        "path": "libs/sdv/run_phase3.py",
+        "description": "SDV PARSynthesizer (128ep) で銘柄別の日次株価時系列を合成"
+      },
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_stock.py",
+        "description": "SDMetrics + 自己相関乖離 + DCR による評価"
+      }
+    ]
   },
   {
     "id": "iot-sensor-monitoring",
@@ -458,6 +618,14 @@
         "privacy_risk": "low"
       }
     ],
-    "recommendation": "PAR 64ep の品質スコアは0.64。 自己相関の平均乖離は0.756。 プライバシーリスクはlow。 122拠点の気温・湿度・気圧の季節変動パターンの再現を評価。PAR は拠点ごとのパターンを学習するが、季節変動の精度に改善余地がある。"
+    "recommendation": "PAR 64ep の品質スコアは0.64。 自己相関の平均乖離は0.756。 プライバシーリスクはlow。 122拠点の気温・湿度・気圧の季節変動パターンの再現を評価。PAR は拠点ごとのパターンを学習するが、季節変動の精度に改善余地がある。",
+    "scripts": [
+      {
+        "role": "evaluate",
+        "library": "evaluation",
+        "path": "libs/evaluation/eval_iot_weather.py",
+        "description": "Daily Weather 2020 の取得・PAR 64ep による合成・SDMetrics + 自己相関 + DCR 評価を1スクリプトで実行"
+      }
+    ]
   }
 ]

--- a/docs/catalog/scripts/add_case_scripts.py
+++ b/docs/catalog/scripts/add_case_scripts.py
@@ -1,0 +1,104 @@
+"""experiment-cases.json の各事例に scripts フィールドを追加する。
+
+Issue #63 対応。手書きで JSON を編集すると壊れやすいので、Python で一括更新する。
+実行: python3 docs/catalog/scripts/add_case_scripts.py
+"""
+import json
+import os
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+CASES_JSON = os.path.join(ROOT, 'docs/catalog/public/data/experiment-cases.json')
+
+SCRIPTS_BY_CASE: dict[str, list[dict]] = {
+    "adult-census-anonymization": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "Adult Census データセットを取得し全ライブラリ共通の processed CSV に整形"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_phase1.py",
+         "description": "SDV の GaussianCopula / CTGAN で単一表合成"},
+        {"role": "synthesize", "library": "synthcity", "path": "libs/synthcity/run_phase1.py",
+         "description": "SynthCity の BayesianNetwork / TVAE / AdsGAN / NFlow で単一表合成"},
+        {"role": "synthesize", "library": "ydata", "path": "libs/ydata/run_phase1.py",
+         "description": "ydata-synthetic の CTGAN で単一表合成"},
+    ],
+    "insurance-risk-modeling": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "SDV demo (insurance) を取得・整形"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_additional_experiments.py",
+         "description": "GaussianCopula / CTGAN で Insurance データを合成"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_insurance.py",
+         "description": "SDMetrics + TSTR + DCR による品質・プライバシー評価"},
+    ],
+    "company-directory": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "SDV demo (Fake Companies) を取得・整形"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_additional_experiments.py",
+         "description": "GaussianCopula で Fake Companies データを合成"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_fake_companies.py",
+         "description": "12行の極小データに対する品質・プライバシー評価"},
+    ],
+    "hotel-reservation-multitable": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "SDV demo (Fake Hotels) を取得し複数表メタデータも保存"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_phase2.py",
+         "description": "SDV HMASynthesizer で hotels / guests を外部キー整合性付きで合成"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_hotel.py",
+         "description": "FK 整合性チェック + 単表 SDMetrics による評価"},
+    ],
+    "imdb-movie-database": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "SDV demo (IMDB Small) を取得し7テーブル分のメタデータを保存"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_additional_experiments.py",
+         "description": "SDV HMASynthesizer で IMDB 7テーブル + 多対多リレーションを合成"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_imdb.py",
+         "description": "6リレーションすべての FK 整合性 + 単表 SDMetrics による評価"},
+    ],
+    "olist-ec-transactions": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_olist.py",
+         "description": "Brazilian E-Commerce (Olist) 7テーブルを uniformly sample (5000 customers ベース) し processed に保存"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_olist_hma.py",
+         "description": "SDV HMASynthesizer で Olist 7/7 テーブルを合成（FK 6本維持）"},
+        {"role": "synthesize", "library": "realtabformer", "path": "libs/realtabformer/run_olist.py",
+         "description": "REaLTabFormer で orders → order_items の親子1ペアを合成（数値分布精度比較用）"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_olist.py",
+         "description": "FK 整合性 + 件数分布 + 単変量分布 + 結合 TSTR (review_score 予測) による評価"},
+    ],
+    "stock-price-timeseries": [
+        {"role": "prepare", "library": "sdv", "path": "libs/sdv/prepare_data.py",
+         "description": "SDV demo (NASDAQ 100 2019) を取得し時系列メタデータを保存"},
+        {"role": "synthesize", "library": "sdv", "path": "libs/sdv/run_phase3.py",
+         "description": "SDV PARSynthesizer (128ep) で銘柄別の日次株価時系列を合成"},
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_stock.py",
+         "description": "SDMetrics + 自己相関乖離 + DCR による評価"},
+    ],
+    "iot-sensor-monitoring": [
+        {"role": "evaluate", "library": "evaluation", "path": "libs/evaluation/eval_iot_weather.py",
+         "description": "Daily Weather 2020 の取得・PAR 64ep による合成・SDMetrics + 自己相関 + DCR 評価を1スクリプトで実行"},
+    ],
+}
+
+
+def main() -> None:
+    with open(CASES_JSON, encoding='utf-8') as f:
+        cases = json.load(f)
+
+    updated = 0
+    skipped: list[str] = []
+    for case in cases:
+        cid = case.get('id')
+        if cid in SCRIPTS_BY_CASE:
+            case['scripts'] = SCRIPTS_BY_CASE[cid]
+            updated += 1
+        else:
+            skipped.append(cid)
+
+    with open(CASES_JSON, 'w', encoding='utf-8') as f:
+        json.dump(cases, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+
+    print(f"Updated {updated} cases.")
+    if skipped:
+        print(f"Skipped (no mapping): {skipped}")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/catalog/src/components/CaseScriptsSection.tsx
+++ b/docs/catalog/src/components/CaseScriptsSection.tsx
@@ -1,0 +1,117 @@
+import { buildBlobUrl, buildRawUrl } from "../constants/repo";
+import { SCRIPT_ROLE_LABELS } from "../types/experiment-case";
+import type { CaseScript, ScriptRole } from "../types/experiment-case";
+
+const ROLE_ORDER: ScriptRole[] = ["prepare", "synthesize", "evaluate"];
+
+function ExternalLinkIcon() {
+  return (
+    <svg
+      className="w-3.5 h-3.5 inline-block"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg
+      className="w-3.5 h-3.5 inline-block"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V4"
+      />
+    </svg>
+  );
+}
+
+function ScriptRow({ script }: { script: CaseScript }) {
+  const fileName = script.path.split("/").pop() ?? script.path;
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-1.5">
+      <code className="text-xs font-mono text-gray-700 break-all">{script.path}</code>
+      {script.description ? (
+        <span className="text-xs text-gray-500">— {script.description}</span>
+      ) : null}
+      <span className="ml-auto inline-flex items-center gap-2">
+        <a
+          href={buildBlobUrl(script.path)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${fileName} を GitHub で表示`}
+          className="inline-flex items-center gap-1 text-xs text-blue-700 hover:text-blue-900 hover:underline"
+        >
+          <ExternalLinkIcon />
+          コード
+        </a>
+        <a
+          href={buildRawUrl(script.path)}
+          target="_blank"
+          rel="noopener noreferrer"
+          download={fileName}
+          aria-label={`${fileName} をダウンロード`}
+          className="inline-flex items-center gap-1 text-xs text-blue-700 hover:text-blue-900 hover:underline"
+        >
+          <DownloadIcon />
+          DL
+        </a>
+      </span>
+    </li>
+  );
+}
+
+export function CaseScriptsSection({ scripts }: { scripts?: CaseScript[] }) {
+  if (!scripts || scripts.length === 0) return null;
+
+  const grouped = ROLE_ORDER.map((role) => ({
+    role,
+    items: scripts.filter((s) => s.role === role),
+  })).filter((g) => g.items.length > 0);
+
+  if (grouped.length === 0) return null;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-6 mb-6">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+        使用したスクリプト
+      </h2>
+      <div className="space-y-4">
+        {grouped.map(({ role, items }) => (
+          <div key={role}>
+            <h3 className="text-xs font-semibold text-gray-600 mb-1">
+              {SCRIPT_ROLE_LABELS[role]}
+              <span className="ml-2 text-[10px] font-normal text-gray-400">{items.length}件</span>
+            </h3>
+            <ul className="divide-y divide-gray-100">
+              {items.map((script) => (
+                <ScriptRow key={`${script.role}-${script.path}`} script={script} />
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-gray-400 mt-4 leading-relaxed">
+        実行には共通ヘルパー（<code className="text-[11px]">libs/common/experiment.py</code>）と各ライブラリの uv 環境が必要です。詳細はリポジトリの README とプロジェクト直下の <code className="text-[11px]">CLAUDE.md</code> を参照してください。
+      </p>
+    </div>
+  );
+}

--- a/docs/catalog/src/pages/CaseDetailPage.test.tsx
+++ b/docs/catalog/src/pages/CaseDetailPage.test.tsx
@@ -54,6 +54,19 @@ const mockCase: ExperimentCase = {
     },
   ],
   recommendation: "CTGAN が最もバランスが良い。",
+  scripts: [
+    {
+      role: "prepare",
+      library: "sdv",
+      path: "libs/sdv/prepare_data.py",
+      description: "Adult Census データセットを取得し processed CSV に整形",
+    },
+    {
+      role: "synthesize",
+      library: "sdv",
+      path: "libs/sdv/run_phase1.py",
+    },
+  ],
 };
 
 // MemoryRouter で指定 id のルートにレンダーするヘルパー
@@ -113,6 +126,37 @@ describe("CaseDetailPage", () => {
     // 結果テーブルに手法名が表示されること（MetricsBarChart などで複数表示されることがあるため getAllByText を使用）
     expect(screen.getAllByText("CTGAN").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("GaussianCopula").length).toBeGreaterThanOrEqual(1);
+
+    // スクリプトセクションが描画されること
+    expect(screen.getByText("使用したスクリプト")).toBeInTheDocument();
+    expect(screen.getByText("データ準備")).toBeInTheDocument();
+    expect(screen.getByText("合成")).toBeInTheDocument();
+    expect(screen.getByText("libs/sdv/prepare_data.py")).toBeInTheDocument();
+
+    // GitHub blob/raw URL が組み立てられていること
+    const blobLink = screen.getAllByRole("link", { name: /prepare_data.py を GitHub で表示/i })[0];
+    expect(blobLink).toHaveAttribute(
+      "href",
+      "https://github.com/gghatano/syntheticdata-generation-catalog/blob/main/libs/sdv/prepare_data.py"
+    );
+    const rawLink = screen.getAllByRole("link", { name: /prepare_data.py をダウンロード/i })[0];
+    expect(rawLink).toHaveAttribute(
+      "href",
+      "https://github.com/gghatano/syntheticdata-generation-catalog/raw/main/libs/sdv/prepare_data.py"
+    );
+  });
+
+  it("(c2) scripts が未指定なら使用したスクリプトセクションは描画されない", () => {
+    const caseWithoutScripts: ExperimentCase = { ...mockCase, scripts: undefined };
+    mockUseExperimentCases.mockReturnValue({
+      cases: [caseWithoutScripts],
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("adult-census-anonymization");
+
+    expect(screen.queryByText("使用したスクリプト")).not.toBeInTheDocument();
   });
 
   it("(d) loading → resolved 遷移を通してクラッシュしない", () => {

--- a/docs/catalog/src/pages/CaseDetailPage.tsx
+++ b/docs/catalog/src/pages/CaseDetailPage.tsx
@@ -6,6 +6,7 @@ import type { CaseResult } from "../types/experiment-case";
 import type { TableData } from "../utils/export";
 import { ExportButtons } from "../components/ExportButtons";
 import { MetricsBarChart } from "../components/MetricsBarChart";
+import { CaseScriptsSection } from "../components/CaseScriptsSection";
 
 const PRIVACY_BADGE: Record<string, { label: string; bg: string; text: string; border: string }> = {
   low: { label: "低リスク", bg: "bg-green-50", text: "text-green-700", border: "border-green-200" },
@@ -232,6 +233,9 @@ export function CaseDetailPage() {
           * Quality Score は SDMetrics による統計的類似性評価（0〜1）。TSTR F1 は合成データで学習→実データでテスト時の F1 スコア（ベースライン: 0.851）。DCR は最近傍距離の平均（高いほどプライバシー保護が強い）。
         </p>
       </div>
+
+      {/* Scripts */}
+      <CaseScriptsSection scripts={c.scripts} />
 
       {/* Recommendation */}
       <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">

--- a/docs/catalog/src/types/experiment-case.ts
+++ b/docs/catalog/src/types/experiment-case.ts
@@ -18,6 +18,21 @@ export const DATA_CATEGORY_ICONS: Record<DataCategory, string> = {
   multi_table: "\uD83D\uDD17",
 };
 
+export type ScriptRole = "prepare" | "synthesize" | "evaluate";
+
+export type CaseScript = {
+  role: ScriptRole;
+  library: string;
+  path: string;
+  description?: string;
+};
+
+export const SCRIPT_ROLE_LABELS: Record<ScriptRole, string> = {
+  prepare: "データ準備",
+  synthesize: "合成",
+  evaluate: "評価",
+};
+
 export type ExperimentCase = {
   id: string;
   title: string;
@@ -35,6 +50,7 @@ export type ExperimentCase = {
   };
   results: CaseResult[];
   recommendation: string;
+  scripts?: CaseScript[];
 };
 
 export type CaseResult = {


### PR DESCRIPTION
## Summary
- 事例詳細ページに「使用したスクリプト」セクションを追加し、GitHub blob URL（コード閲覧）と raw URL（DL）を提供
- 8 事例すべてに `scripts` フィールドを追加（adult / insurance / company / hotel / imdb / olist / stock / iot）
- スキーマは `{role: prepare|synthesize|evaluate, library, path, description?}`。role は固定順 (prepare → synthesize → evaluate) でグルーピング表示
- 共通ヘルパー (`libs/common/experiment.py`) と uv 環境が必要な旨をセクション末尾に注記

## Changes
- `docs/catalog/src/types/experiment-case.ts`: `ScriptRole`, `CaseScript`, `SCRIPT_ROLE_LABELS` を追加。`ExperimentCase` に `scripts?: CaseScript[]` を追加
- `docs/catalog/src/components/CaseScriptsSection.tsx`: 新規。role別カード表示、外部リンク/DLアイコンはインライン SVG
- `docs/catalog/src/pages/CaseDetailPage.tsx`: おすすめセクション直前に `<CaseScriptsSection scripts={c.scripts} />` を挿入
- `docs/catalog/public/data/experiment-cases.json`: 全 8 事例に scripts を追加
- `docs/catalog/scripts/add_case_scripts.py`: 一括投入スクリプト（再実行・追加に使える）
- `docs/catalog/src/pages/CaseDetailPage.test.tsx`: スクリプトセクション描画 / URL 組立 / scripts なし時非表示の検証を追加

## スクリプト対応表
| case_id | prepare | synthesize | evaluate |
|---|---|---|---|
| adult-census-anonymization | sdv/prepare_data.py | sdv/run_phase1.py, synthcity/run_phase1.py, ydata/run_phase1.py | （なし） |
| insurance-risk-modeling | sdv/prepare_data.py | sdv/run_additional_experiments.py | evaluation/eval_insurance.py |
| company-directory | sdv/prepare_data.py | sdv/run_additional_experiments.py | evaluation/eval_fake_companies.py |
| hotel-reservation-multitable | sdv/prepare_data.py | sdv/run_phase2.py | evaluation/eval_hotel.py |
| imdb-movie-database | sdv/prepare_data.py | sdv/run_additional_experiments.py | evaluation/eval_imdb.py |
| olist-ec-transactions | sdv/prepare_olist.py | sdv/run_olist_hma.py, realtabformer/run_olist.py | evaluation/eval_olist.py |
| stock-price-timeseries | sdv/prepare_data.py | sdv/run_phase3.py | evaluation/eval_stock.py |
| iot-sensor-monitoring | （eval に内包） | （eval に内包） | evaluation/eval_iot_weather.py |

## Test plan
- [x] `npm run lint` 通過
- [x] `npm run test` 全 35 件通過（+1 件追加）
- [x] `npm run build` 成功
- [ ] dev server で各事例ページに「使用したスクリプト」セクションが正しく表示されることを目視確認
- [ ] blob/raw リンクで GitHub の該当ファイルに飛べることを確認

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)