### PR TITLE
develop → main: Issue #22 (ライブラリ間比較チャート) リリース

### DIFF
--- a/docs/catalog/src/components/LibraryComparisonChart.test.tsx
+++ b/docs/catalog/src/components/LibraryComparisonChart.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LibraryComparisonChart } from "./LibraryComparisonChart";
+import type { Experiment } from "../types/algorithm";
+
+const ctganExperiments: Experiment[] = [
+  {
+    id: "phase1_sdv_ctgan",
+    library: "SDV",
+    library_version: "1.27.0",
+    params: { epochs: 100 },
+    dataset: "d1_adult",
+    data_type: "single_table",
+    phase: "phase1",
+    metrics: {
+      quality_score: 0.86,
+      tstr_f1: 0.82,
+      dcr_mean: 0.34,
+      time_sec: 325.2,
+    },
+  },
+  {
+    id: "phase1_synthcity_ctgan",
+    library: "SynthCity",
+    library_version: "0.2.7",
+    params: {},
+    dataset: "d1_adult",
+    data_type: "single_table",
+    phase: "phase1",
+    metrics: {
+      quality_score: 0.74,
+      tstr_f1: 0.78,
+      dcr_mean: 0.29,
+      time_sec: 200.0,
+    },
+  },
+  {
+    id: "phase1_ydata_ctgan",
+    library: "ydata-synthetic",
+    library_version: "1.4.0",
+    params: { epochs: 100 },
+    dataset: "d1_adult",
+    data_type: "single_table",
+    phase: "phase1",
+    metrics: {
+      quality_score: 0.83,
+      tstr_f1: 0.81,
+      dcr_mean: 0.26,
+      time_sec: 1464.3,
+    },
+  },
+];
+
+describe("LibraryComparisonChart", () => {
+  it("(a) 2+ ライブラリが揃っている場合、ヘッダー / インサイト / テーブルが表示される", () => {
+    render(<LibraryComparisonChart experiments={ctganExperiments} algorithmName="CTGAN" />);
+
+    expect(screen.getByText("ライブラリ間比較")).toBeInTheDocument();
+
+    // ライブラリ名がテーブルに表示される
+    expect(screen.getByText("SDV")).toBeInTheDocument();
+    expect(screen.getByText("SynthCity")).toBeInTheDocument();
+    expect(screen.getByText("ydata-synthetic")).toBeInTheDocument();
+
+    // インサイトが Quality 最高(SDV 0.86) と最低(SynthCity 0.74) を引用
+    const insightHits = screen.getAllByText(/同じ CTGAN でも.*SDV.*Quality 0\.86.*SynthCity.*Quality 0\.74/);
+    expect(insightHits.length).toBeGreaterThan(0);
+  });
+
+  it("(b) 1 ライブラリのみの場合は描画しない", () => {
+    const { container } = render(
+      <LibraryComparisonChart
+        experiments={[ctganExperiments[0]]}
+        algorithmName="CTGAN"
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("(c) 同一ライブラリで複数 experiment がある場合、Quality 最高のものを代表値に採用", () => {
+    const exps: Experiment[] = [
+      ...ctganExperiments,
+      {
+        id: "phase1_sdv_ctgan_300ep",
+        library: "SDV",
+        library_version: "1.27.0",
+        params: { epochs: 300 },
+        dataset: "d1_adult",
+        data_type: "single_table",
+        phase: "phase1",
+        metrics: {
+          quality_score: 0.91,
+          tstr_f1: 0.85,
+          dcr_mean: 0.30,
+          time_sec: 980.0,
+        },
+      },
+    ];
+    render(<LibraryComparisonChart experiments={exps} algorithmName="CTGAN" />);
+    // SDV 行に Quality 0.91 が表示される
+    expect(screen.getByText("0.910")).toBeInTheDocument();
+    // 実験数 2 が SDV 行に表示
+    expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/docs/catalog/src/components/LibraryComparisonChart.tsx
+++ b/docs/catalog/src/components/LibraryComparisonChart.tsx
@@ -1,0 +1,172 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { Experiment } from "../types/algorithm";
+
+const QUALITY_COLOR = "#2563eb";
+const TSTR_COLOR = "#10b981";
+const DCR_COLOR = "#f97316";
+
+type LibrarySummary = {
+  library: string;
+  experiment_count: number;
+  quality_score?: number;
+  tstr_f1?: number;
+  dcr_mean?: number;
+  time_sec?: number;
+  params_text: string;
+};
+
+function pickBestExperiment(experiments: Experiment[]): Experiment {
+  // Quality 最高の experiment を採用。Quality が無ければ TSTR F1、それも無ければ最初の experiment
+  const sorted = [...experiments].sort((a, b) => {
+    const aq = a.metrics.quality_score ?? a.metrics.tstr_f1 ?? -1;
+    const bq = b.metrics.quality_score ?? b.metrics.tstr_f1 ?? -1;
+    return bq - aq;
+  });
+  return sorted[0];
+}
+
+function summarizeByLibrary(experiments: Experiment[]): LibrarySummary[] {
+  const grouped = new Map<string, Experiment[]>();
+  for (const exp of experiments) {
+    const lib = exp.library;
+    if (!grouped.has(lib)) grouped.set(lib, []);
+    grouped.get(lib)!.push(exp);
+  }
+  const summaries: LibrarySummary[] = [];
+  for (const [library, exps] of grouped) {
+    const best = pickBestExperiment(exps);
+    const paramEntries = Object.entries(best.params);
+    const params_text =
+      paramEntries.length === 0
+        ? "default"
+        : paramEntries.map(([k, v]) => `${k}=${v}`).join(", ");
+    summaries.push({
+      library,
+      experiment_count: exps.length,
+      quality_score: best.metrics.quality_score,
+      tstr_f1: best.metrics.tstr_f1,
+      dcr_mean: best.metrics.dcr_mean,
+      time_sec: best.metrics.time_sec,
+      params_text,
+    });
+  }
+  // Quality 降順で固定（読み手が「上位」を見やすいよう）
+  summaries.sort((a, b) => (b.quality_score ?? -1) - (a.quality_score ?? -1));
+  return summaries;
+}
+
+function buildInsightText(summaries: LibrarySummary[], algorithmName: string): string | null {
+  if (summaries.length < 2) return null;
+  const withQuality = summaries.filter((s) => s.quality_score != null);
+  if (withQuality.length < 2) return null;
+  const top = withQuality[0];
+  const bottom = withQuality[withQuality.length - 1];
+  const diff = (top.quality_score! - bottom.quality_score!).toFixed(2);
+  return (
+    `同じ ${algorithmName} でも ${top.library} 版は Quality ${top.quality_score!.toFixed(2)}、` +
+    `${bottom.library} 版は Quality ${bottom.quality_score!.toFixed(2)} と ${diff} の差。`
+  );
+}
+
+export function LibraryComparisonChart({
+  experiments,
+  algorithmName,
+}: {
+  experiments: Experiment[];
+  algorithmName: string;
+}) {
+  const summaries = summarizeByLibrary(experiments);
+  if (summaries.length < 2) return null;
+
+  const chartData = summaries.map((s) => ({
+    name: s.library,
+    Quality: s.quality_score != null ? Math.round(s.quality_score * 1000) / 1000 : null,
+    "TSTR F1": s.tstr_f1 != null ? Math.round(s.tstr_f1 * 1000) / 1000 : null,
+    "DCR Mean": s.dcr_mean != null ? Math.round(s.dcr_mean * 1000) / 1000 : null,
+  }));
+
+  const insight = buildInsightText(summaries, algorithmName);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+      <div className="mb-3">
+        <h2 className="font-semibold text-gray-800 text-lg">ライブラリ間比較</h2>
+        <p className="text-xs text-gray-500 mt-1 leading-relaxed">
+          同じ {algorithmName} アルゴリズムを各ライブラリが実装した場合の Quality / TSTR F1 / DCR Mean を比較。各ライブラリの代表値は Quality 最高の実験を採用。
+        </p>
+      </div>
+
+      <div className="h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="name" tick={{ fontSize: 12, fill: "#374151" }} />
+            <YAxis domain={[0, 1]} tick={{ fontSize: 11, fill: "#6b7280" }} />
+            <Tooltip
+              contentStyle={{ fontSize: 12 }}
+              formatter={(value) =>
+                typeof value === "number" ? value.toFixed(3) : value
+              }
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Bar dataKey="Quality" fill={QUALITY_COLOR} fillOpacity={0.85} />
+            <Bar dataKey="TSTR F1" fill={TSTR_COLOR} fillOpacity={0.85} />
+            <Bar dataKey="DCR Mean" fill={DCR_COLOR} fillOpacity={0.85} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {insight ? (
+        <p className="text-sm text-blue-900 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 mt-3 leading-relaxed">
+          💡 {insight}
+        </p>
+      ) : null}
+
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-gray-500 border-b border-gray-200">
+              <th className="px-2 py-1.5 font-semibold">ライブラリ</th>
+              <th className="px-2 py-1.5 font-semibold">代表 params</th>
+              <th className="px-2 py-1.5 font-semibold text-right">実験数</th>
+              <th className="px-2 py-1.5 font-semibold text-right">Quality</th>
+              <th className="px-2 py-1.5 font-semibold text-right">TSTR F1</th>
+              <th className="px-2 py-1.5 font-semibold text-right">DCR Mean</th>
+              <th className="px-2 py-1.5 font-semibold text-right">時間 (秒)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summaries.map((s) => (
+              <tr key={s.library} className="border-b border-gray-100">
+                <td className="px-2 py-1.5 font-medium">{s.library}</td>
+                <td className="px-2 py-1.5 font-mono text-gray-600">{s.params_text}</td>
+                <td className="px-2 py-1.5 text-right text-gray-600">{s.experiment_count}</td>
+                <td className="px-2 py-1.5 text-right font-mono">
+                  {s.quality_score != null ? s.quality_score.toFixed(3) : "—"}
+                </td>
+                <td className="px-2 py-1.5 text-right font-mono">
+                  {s.tstr_f1 != null ? s.tstr_f1.toFixed(3) : "—"}
+                </td>
+                <td className="px-2 py-1.5 text-right font-mono">
+                  {s.dcr_mean != null ? s.dcr_mean.toFixed(3) : "—"}
+                </td>
+                <td className="px-2 py-1.5 text-right text-gray-500">
+                  {s.time_sec != null ? s.time_sec.toFixed(1) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/docs/catalog/src/pages/DetailPage.tsx
+++ b/docs/catalog/src/pages/DetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAlgorithms } from "../hooks/useAlgorithms";
 import { useExperimentCases } from "../hooks/useExperimentCases";
@@ -6,6 +6,12 @@ import { CATEGORY_LABELS, DATA_TYPE_LABELS } from "../constants/categories";
 import { MetricsBadge } from "../components/MetricsBadge";
 import { ExperimentTable } from "../components/ExperimentTable";
 import { QuickStartSection } from "../components/QuickStartSection";
+
+const LibraryComparisonChart = lazy(() =>
+  import("../components/LibraryComparisonChart").then((m) => ({
+    default: m.LibraryComparisonChart,
+  }))
+);
 import type { PrivacyRiskLevel } from "../types/algorithm";
 import { DATA_CATEGORY_ICONS, DATA_CATEGORY_LABELS } from "../types/experiment-case";
 
@@ -326,6 +332,14 @@ export function DetailPage() {
           </div>
         </div>
       )}
+
+      {/* Library Comparison Chart (only when 2+ libraries implement this algorithm) */}
+      <Suspense fallback={null}>
+        <LibraryComparisonChart
+          experiments={algorithm.experiments}
+          algorithmName={algorithm.name}
+        />
+      </Suspense>
 
       {/* Experiments Table */}
       <div className="bg-white rounded-lg shadow-md p-6 mb-6">


### PR DESCRIPTION
Issue #22 の対応をリリース。

## 含まれる変更
- **#22** ([PR #80](https://github.com/gghatano/syntheticdata-generation-catalog/pull/80)) — AlgorithmDetailPage にライブラリ間比較バーチャートを追加。Quality / TSTR F1 / DCR Mean を 3 ライブラリ間で比較できる

## 動作確認済み
- `npm run lint` 通過 / `npm run test` 全 42 件通過 / `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)