### PR TITLE
develop → main: Issue #18 (ComparePage) リリース

### DIFF
--- a/docs/catalog/src/App.tsx
+++ b/docs/catalog/src/App.tsx
@@ -3,6 +3,8 @@ import { Layout } from "./components/layout/Layout";
 import { ListPage } from "./pages/ListPage";
 import { DetailPage } from "./pages/DetailPage";
 import { CaseDetailPage } from "./pages/CaseDetailPage";
+import { ComparePage } from "./pages/ComparePage";
+import { FloatingCompareBar } from "./components/FloatingCompareBar";
 
 const basename = import.meta.env.BASE_URL;
 
@@ -14,7 +16,9 @@ function App() {
           <Route path="/" element={<ListPage />} />
           <Route path="/algorithm/:id" element={<DetailPage />} />
           <Route path="/case/:id" element={<CaseDetailPage />} />
+          <Route path="/compare" element={<ComparePage />} />
         </Routes>
+        <FloatingCompareBar />
       </Layout>
     </BrowserRouter>
   );

--- a/docs/catalog/src/components/AlgorithmCard.tsx
+++ b/docs/catalog/src/components/AlgorithmCard.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import type { Algorithm } from "../types/algorithm";
 import { CATEGORY_LABELS, DATA_TYPE_LABELS } from "../constants/categories";
 import { MetricsBadge } from "./MetricsBadge";
+import { CompareToggleButton } from "./CompareToggleButton";
 
 type AlgorithmCardProps = {
   algorithm: Algorithm;
@@ -81,8 +82,8 @@ export function AlgorithmCard({ algorithm }: AlgorithmCardProps) {
         </div>
       )}
 
-      {/* Library badges */}
-      <div className="flex flex-wrap gap-1.5 pt-3 border-t border-gray-100">
+      {/* Library badges + compare toggle */}
+      <div className="flex flex-wrap items-center gap-1.5 pt-3 border-t border-gray-100">
         {libraries.map((lib) => (
           <span
             key={lib}
@@ -91,6 +92,9 @@ export function AlgorithmCard({ algorithm }: AlgorithmCardProps) {
             {lib}
           </span>
         ))}
+        <span className="ml-auto">
+          <CompareToggleButton algorithmId={id} algorithmName={name} />
+        </span>
       </div>
     </Link>
   );

--- a/docs/catalog/src/components/CompareToggleButton.tsx
+++ b/docs/catalog/src/components/CompareToggleButton.tsx
@@ -1,0 +1,64 @@
+import { useCompareSelection } from "../hooks/useCompareSelection";
+
+export function CompareToggleButton({
+  algorithmId,
+  algorithmName,
+}: {
+  algorithmId: string;
+  algorithmName: string;
+}) {
+  const { has, toggle, isFull } = useCompareSelection();
+  const checked = has(algorithmId);
+  const disabled = !checked && isFull;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    toggle(algorithmId);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      aria-pressed={checked}
+      aria-label={
+        checked
+          ? `${algorithmName} を比較対象から外す`
+          : `${algorithmName} を比較対象に追加`
+      }
+      title={
+        disabled
+          ? "比較対象は最大 3 件まで"
+          : checked
+          ? "比較対象から外す"
+          : "比較対象に追加"
+      }
+      className={
+        "inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-full border transition-colors " +
+        (checked
+          ? "bg-blue-600 text-white border-blue-600 hover:bg-blue-700"
+          : disabled
+          ? "bg-gray-50 text-gray-400 border-gray-200 cursor-not-allowed"
+          : "bg-white text-gray-600 border-gray-300 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300")
+      }
+    >
+      <svg
+        className="w-3.5 h-3.5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        {checked ? (
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        ) : (
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        )}
+      </svg>
+      {checked ? "比較中" : "比較に追加"}
+    </button>
+  );
+}

--- a/docs/catalog/src/components/FloatingCompareBar.tsx
+++ b/docs/catalog/src/components/FloatingCompareBar.tsx
@@ -1,0 +1,78 @@
+import { Link } from "react-router-dom";
+import { useCompareSelection } from "../hooks/useCompareSelection";
+import { useAlgorithms } from "../hooks/useAlgorithms";
+
+export function FloatingCompareBar() {
+  const { selected, remove, clear, max } = useCompareSelection();
+  const { algorithms } = useAlgorithms();
+
+  if (selected.length === 0) return null;
+
+  const idToName = new Map(algorithms.map((a) => [a.id, a.name]));
+
+  const compareHref = `/compare?ids=${selected.join(",")}`;
+  const canCompare = selected.length >= 2;
+
+  return (
+    <div
+      role="region"
+      aria-label="比較対象選択中"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 max-w-3xl w-[calc(100%-2rem)]"
+    >
+      <div className="bg-white border border-gray-200 rounded-2xl shadow-2xl px-4 py-3 flex items-center gap-3">
+        <span className="text-sm font-semibold text-gray-700 shrink-0">
+          {selected.length}/{max} 件選択中
+        </span>
+
+        <div className="flex-1 flex flex-wrap gap-1.5 min-w-0">
+          {selected.map((id) => (
+            <span
+              key={id}
+              className="inline-flex items-center gap-1 bg-blue-50 text-blue-700 text-xs font-medium px-2 py-0.5 rounded-full border border-blue-200"
+            >
+              {idToName.get(id) ?? id}
+              <button
+                type="button"
+                onClick={() => remove(id)}
+                aria-label={`${idToName.get(id) ?? id} を比較対象から外す`}
+                className="hover:text-blue-900"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={clear}
+          className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 shrink-0"
+        >
+          すべてクリア
+        </button>
+
+        <Link
+          to={compareHref}
+          aria-disabled={!canCompare}
+          onClick={(e) => {
+            if (!canCompare) e.preventDefault();
+          }}
+          className={
+            "inline-flex items-center gap-1 px-4 py-2 rounded-full text-sm font-semibold shrink-0 " +
+            (canCompare
+              ? "bg-blue-600 text-white hover:bg-blue-700"
+              : "bg-gray-200 text-gray-400 cursor-not-allowed")
+          }
+          title={canCompare ? "比較ページへ" : "2件以上を選択してください"}
+        >
+          比較する
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/docs/catalog/src/hooks/useCompareSelection.test.ts
+++ b/docs/catalog/src/hooks/useCompareSelection.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useCompareSelection } from "./useCompareSelection";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useCompareSelection", () => {
+  it("(a) toggle で 1 件追加され has が true になる", () => {
+    const { result } = renderHook(() => useCompareSelection());
+    expect(result.current.selected).toEqual([]);
+
+    act(() => result.current.toggle("ctgan"));
+    expect(result.current.selected).toEqual(["ctgan"]);
+    expect(result.current.has("ctgan")).toBe(true);
+  });
+
+  it("(b) toggle で同じ id を 2 回押すと外れる", () => {
+    const { result } = renderHook(() => useCompareSelection());
+    act(() => result.current.toggle("ctgan"));
+    act(() => result.current.toggle("ctgan"));
+    expect(result.current.selected).toEqual([]);
+    expect(result.current.has("ctgan")).toBe(false);
+  });
+
+  it("(c) 最大 3 件まで。4 件目は無視される", () => {
+    const { result } = renderHook(() => useCompareSelection());
+    act(() => {
+      result.current.toggle("a");
+      result.current.toggle("b");
+      result.current.toggle("c");
+      result.current.toggle("d");
+    });
+    expect(result.current.selected).toEqual(["a", "b", "c"]);
+    expect(result.current.isFull).toBe(true);
+  });
+
+  it("(d) localStorage に永続化され、再 mount で復元される", () => {
+    const { result, unmount } = renderHook(() => useCompareSelection());
+    act(() => result.current.toggle("ctgan"));
+    act(() => result.current.toggle("tvae"));
+    unmount();
+
+    const { result: result2 } = renderHook(() => useCompareSelection());
+    expect(result2.current.selected).toEqual(["ctgan", "tvae"]);
+  });
+
+  it("(e) clear ですべて空になる", () => {
+    const { result } = renderHook(() => useCompareSelection());
+    act(() => {
+      result.current.toggle("a");
+      result.current.toggle("b");
+    });
+    act(() => result.current.clear());
+    expect(result.current.selected).toEqual([]);
+  });
+
+  it("(f) remove で指定 id だけ外れる", () => {
+    const { result } = renderHook(() => useCompareSelection());
+    act(() => {
+      result.current.toggle("a");
+      result.current.toggle("b");
+    });
+    act(() => result.current.remove("a"));
+    expect(result.current.selected).toEqual(["b"]);
+  });
+});

--- a/docs/catalog/src/hooks/useCompareSelection.ts
+++ b/docs/catalog/src/hooks/useCompareSelection.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "syntheticdata-catalog-compare-selection";
+const MAX_SELECTION = 3;
+
+function readStorage(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === "string").slice(0, MAX_SELECTION);
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(ids: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // localStorage が使えない環境（SSR・Privacy mode など）は無視
+  }
+}
+
+/**
+ * 比較選択中アルゴリズムの状態を localStorage と同期する。
+ * 最大 3 件。すでに含まれていれば toggle で外す。
+ */
+export function useCompareSelection() {
+  const [selected, setSelected] = useState<string[]>(() => readStorage());
+
+  useEffect(() => {
+    writeStorage(selected);
+  }, [selected]);
+
+  // 別タブで storage が更新された場合の同期
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        setSelected(readStorage());
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((cur) => {
+      if (cur.includes(id)) return cur.filter((x) => x !== id);
+      if (cur.length >= MAX_SELECTION) return cur;
+      return [...cur, id];
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setSelected((cur) => cur.filter((x) => x !== id));
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelected([]);
+  }, []);
+
+  const has = useCallback((id: string) => selected.includes(id), [selected]);
+
+  const isFull = selected.length >= MAX_SELECTION;
+
+  return { selected, toggle, remove, clear, has, isFull, max: MAX_SELECTION };
+}

--- a/docs/catalog/src/pages/ComparePage.tsx
+++ b/docs/catalog/src/pages/ComparePage.tsx
@@ -1,0 +1,304 @@
+import { useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useAlgorithms } from "../hooks/useAlgorithms";
+import { useCompareSelection } from "../hooks/useCompareSelection";
+import { CATEGORY_LABELS } from "../constants/categories";
+import type { Algorithm, Experiment } from "../types/algorithm";
+
+const BASELINE_F1 = 0.8513;
+
+type MetricRow = {
+  key: string;
+  label: string;
+  formatter: (v: number | undefined | null) => string;
+  /** 高いほど良い? */
+  higherIsBetter: boolean;
+  /** Quality / TSTR / DCR の colorFn 適用範囲（任意）*/
+  cellClass?: (v: number | null | undefined, all: (number | null | undefined)[]) => string;
+};
+
+function fmtPct(v: number | undefined | null): string {
+  if (v == null) return "—";
+  return (v * 100).toFixed(1) + "%";
+}
+
+function fmtNum3(v: number | undefined | null): string {
+  if (v == null) return "—";
+  return v.toFixed(3);
+}
+
+function fmtTime(v: number | undefined | null): string {
+  if (v == null) return "—";
+  if (v < 60) return `${v.toFixed(1)}秒`;
+  const min = Math.floor(v / 60);
+  const sec = v % 60;
+  if (min < 60) return `${min}分${sec >= 30 ? "半" : ""}`;
+  const hr = Math.floor(min / 60);
+  return `${hr}時間${min % 60}分`;
+}
+
+/** 同じ列内で値が最良/最悪のセルに色付け。null は無視 */
+function rankCellClass(
+  value: number | null | undefined,
+  allValues: (number | null | undefined)[],
+  higherIsBetter: boolean
+): string {
+  if (value == null) return "";
+  const nums = allValues.filter((v): v is number => v != null);
+  if (nums.length < 2) return "";
+  const best = higherIsBetter ? Math.max(...nums) : Math.min(...nums);
+  const worst = higherIsBetter ? Math.min(...nums) : Math.max(...nums);
+  if (value === best && best !== worst) return "bg-green-50 text-green-800 font-semibold";
+  if (value === worst && best !== worst) return "bg-red-50 text-red-800";
+  return "";
+}
+
+function pickBest(experiments: Experiment[]): Experiment | undefined {
+  if (experiments.length === 0) return undefined;
+  return [...experiments].sort((a, b) => {
+    const aq = a.metrics.quality_score ?? a.metrics.tstr_f1 ?? -1;
+    const bq = b.metrics.quality_score ?? b.metrics.tstr_f1 ?? -1;
+    return bq - aq;
+  })[0];
+}
+
+const METRIC_ROWS: MetricRow[] = [
+  {
+    key: "quality",
+    label: "Quality",
+    formatter: fmtPct,
+    higherIsBetter: true,
+  },
+  {
+    key: "tstr_f1",
+    label: "TSTR F1",
+    formatter: (v) => (v == null ? "—" : `${v.toFixed(3)} (vs ベースライン ${BASELINE_F1})`),
+    higherIsBetter: true,
+  },
+  {
+    key: "dcr_mean",
+    label: "DCR Mean",
+    formatter: fmtNum3,
+    higherIsBetter: true,
+  },
+  {
+    key: "time",
+    label: "実行時間",
+    formatter: fmtTime,
+    higherIsBetter: false,
+  },
+];
+
+function getMetricValue(alg: Algorithm, key: string): number | undefined {
+  const best = pickBest(alg.experiments);
+  if (!best) return undefined;
+  switch (key) {
+    case "quality":
+      return best.metrics.quality_score ?? alg.summary_metrics?.best_quality_score;
+    case "tstr_f1":
+      return best.metrics.tstr_f1 ?? alg.summary_metrics?.best_tstr_f1;
+    case "dcr_mean":
+      return best.metrics.dcr_mean ?? alg.summary_metrics?.best_dcr_mean;
+    case "time":
+      return best.metrics.time_sec ?? alg.summary_metrics?.fastest_time_sec;
+    default:
+      return undefined;
+  }
+}
+
+function getRepresentativeDataset(alg: Algorithm): string | undefined {
+  const best = pickBest(alg.experiments);
+  return best?.dataset;
+}
+
+export function ComparePage() {
+  const [searchParams] = useSearchParams();
+  const { algorithms, loading, error } = useAlgorithms();
+  const { selected, remove, clear } = useCompareSelection();
+
+  const ids = useMemo(() => {
+    const param = searchParams.get("ids");
+    if (param) return param.split(",").map((s) => s.trim()).filter(Boolean);
+    // URL に ids が無ければ localStorage の選択を使う
+    return selected;
+  }, [searchParams, selected]);
+
+  const compared = useMemo(
+    () => ids.map((id) => algorithms.find((a) => a.id === id)).filter((a): a is Algorithm => !!a),
+    [ids, algorithms]
+  );
+
+  if (loading) return <div className="flex justify-center py-20 text-gray-500">読み込み中...</div>;
+  if (error) return <div className="flex justify-center py-20 text-red-500">エラー: {error}</div>;
+
+  if (compared.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto py-10 text-center">
+        <h1 className="text-2xl font-bold text-gray-800 mb-3">比較対象がありません</h1>
+        <p className="text-gray-600 mb-6">
+          一覧ページで「比較に追加」ボタンを押してアルゴリズムを 2〜3 件選択してから戻ってきてください。
+        </p>
+        <Link
+          to="/"
+          className="inline-block bg-blue-600 text-white px-5 py-2.5 rounded-full text-sm font-semibold hover:bg-blue-700"
+        >
+          一覧ページへ
+        </Link>
+      </div>
+    );
+  }
+
+  // 同一データセットでの比較かを判定
+  const datasets = new Set(compared.map(getRepresentativeDataset).filter(Boolean) as string[]);
+  const sameDataset = datasets.size === 1;
+
+  return (
+    <div className="max-w-5xl mx-auto pb-32">
+      <Link
+        to="/"
+        className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 mb-4"
+      >
+        ← 一覧に戻る
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">手法の横並び比較</h1>
+        <p className="text-sm text-gray-600">
+          選択した {compared.length} 件のアルゴリズムを Quality / TSTR / DCR / 時間で比較します。各アルゴリズムの代表値は Quality 最高の experiment を採用しています。
+        </p>
+      </div>
+
+      {!sameDataset && (
+        <div
+          role="alert"
+          className="bg-amber-50 border border-amber-200 text-amber-900 rounded-lg px-4 py-3 mb-4 text-sm"
+        >
+          ⚠️ 異なるデータセット（
+          {Array.from(datasets).join(" / ")}
+          ）の結果を並べています。スコアの直接比較には注意してください（同一データセット同士の比較が原則）。
+        </div>
+      )}
+
+      <div className="overflow-x-auto bg-white rounded-xl border border-gray-200 shadow-sm">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-gray-50 border-b border-gray-200">
+              <th className="px-4 py-3 text-left font-semibold text-gray-600 sticky left-0 bg-gray-50 z-10 min-w-[140px]">
+                指標
+              </th>
+              {compared.map((alg) => (
+                <th
+                  key={alg.id}
+                  className="px-4 py-3 text-left font-semibold text-gray-700 align-top min-w-[180px]"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <Link
+                        to={`/algorithm/${alg.id}`}
+                        className="text-blue-700 hover:underline"
+                      >
+                        {alg.name}
+                      </Link>
+                      <div className="text-[11px] text-gray-500 font-normal mt-0.5">
+                        {CATEGORY_LABELS[alg.category]} ・{" "}
+                        {getRepresentativeDataset(alg) ?? "—"}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => remove(alg.id)}
+                      title="比較から外す"
+                      aria-label={`${alg.name} を比較から外す`}
+                      className="text-gray-400 hover:text-red-600 shrink-0"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {METRIC_ROWS.map((row) => {
+              const values = compared.map((alg) => getMetricValue(alg, row.key));
+              return (
+                <tr key={row.key} className="border-b border-gray-100">
+                  <th className="px-4 py-3 text-left font-medium text-gray-700 sticky left-0 bg-white z-10 align-top">
+                    {row.label}
+                  </th>
+                  {compared.map((alg, i) => {
+                    const v = values[i];
+                    const cls = rankCellClass(v, values, row.higherIsBetter);
+                    return (
+                      <td
+                        key={alg.id}
+                        className={`px-4 py-3 align-top ${cls}`.trim()}
+                      >
+                        {row.formatter(v)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+
+            {/* ライブラリと対応データ型の補足 */}
+            <tr className="border-b border-gray-100 bg-gray-50/40">
+              <th className="px-4 py-3 text-left font-medium text-gray-700 sticky left-0 bg-gray-50/40 z-10 align-top">
+                ライブラリ
+              </th>
+              {compared.map((alg) => (
+                <td key={alg.id} className="px-4 py-3 align-top">
+                  <div className="flex flex-wrap gap-1">
+                    {alg.libraries.map((lib) => (
+                      <span
+                        key={lib}
+                        className="text-[11px] bg-white border border-gray-200 rounded-full px-2 py-0.5 text-gray-600"
+                      >
+                        {lib}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+              ))}
+            </tr>
+
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-gray-700 sticky left-0 bg-white z-10 align-top">
+                強み（要約）
+              </th>
+              {compared.map((alg) => (
+                <td key={alg.id} className="px-4 py-3 text-xs text-gray-700 align-top">
+                  <ul className="list-disc list-inside space-y-0.5">
+                    {alg.strengths.slice(0, 3).map((s, i) => (
+                      <li key={i}>{s}</li>
+                    ))}
+                  </ul>
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between mt-4">
+        <p className="text-xs text-gray-500">
+          色付き: 緑=各指標で最良 / 赤=最悪。null セルは「—」表示。各セルは <Link to="/algorithm" className="hidden" /> 各手法の詳細ページから個別に確認可能。
+        </p>
+        <button
+          type="button"
+          onClick={clear}
+          className="text-xs text-gray-500 hover:text-gray-700"
+        >
+          選択をクリア
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-400 mt-4">
+        この URL は <code className="text-[11px]">?ids=...</code> をブックマーク・共有することで状態を保持できます。
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Issue #18 の対応をリリース。

## 含まれる変更
- **#18** ([PR #82](https://github.com/gghatano/syntheticdata-generation-catalog/pull/82)) — 2-3 アルゴリズムの横並び比較機能。一覧カードでトグル選択 → フローティングバー → `/compare?ids=...` で比較表

## 動作確認済み
- `npm run lint` 通過 / `npm run test` 全 48 件通過 / `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)